### PR TITLE
Restore errno instead of setting it to 0

### DIFF
--- a/devices/cusegaps/cusegaps_net.c
+++ b/devices/cusegaps/cusegaps_net.c
@@ -145,9 +145,13 @@ static void writer_open(fuse_req_t req, struct fuse_file_info *fi) {
     fuse_reply_err(req, errno);
     return;
   }
-  while (connect(writer_fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr))) {
+  for (;;) {
+    err = errno;
+    if (connect(writer_fd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) == 0) {
+      break;
+    }
     if (errno == ECONNREFUSED) {
-      errno = 0;
+      errno = err;
       if (!nanosleep(&tim, NULL)) {
         continue;
       }

--- a/devices/cusegaps/cusegaps_pipe.c
+++ b/devices/cusegaps/cusegaps_pipe.c
@@ -50,7 +50,7 @@ static const char *usage =
 
 static void cusegaps_open(fuse_req_t req, struct fuse_file_info *fi) {
   char pathname[128];
-  int rv, flags, *fd_p;
+  int err, rv, flags, *fd_p;
 
   flags = fi->flags & 0x3;
   switch (flags) {
@@ -71,10 +71,11 @@ static void cusegaps_open(fuse_req_t req, struct fuse_file_info *fi) {
   }
 
   snprintf(pathname, sizeof(pathname) - 1, PIRATE_FILENAME, dev_name);
+  err = errno;
   rv = mkfifo(pathname, 0660);
   if (rv == -1) {
     if (errno == EEXIST) {
-      errno = 0;
+      errno = err;
     } else {
       fuse_reply_err(req, errno);
       return;

--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -153,7 +153,7 @@ int pirate_ge_eth_parse_param(char *str, pirate_ge_eth_param_t *param) {
 }
 
 static int ge_eth_reader_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
-    int rv;
+    int err, rv;
     struct sockaddr_in addr;
 
     ctx->sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -169,7 +169,7 @@ static int ge_eth_reader_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     int enable = 1;
     rv = setsockopt(ctx->sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
     if (rv < 0) {
-        int err = errno;
+        err = errno;
         close(ctx->sock);
         ctx->sock = -1;
         errno = err;
@@ -178,7 +178,7 @@ static int ge_eth_reader_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
 
     rv = bind(ctx->sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in));
     if (rv < 0) {
-        int err = errno;
+        err = errno;
         close(ctx->sock);
         ctx->sock = -1;
         errno = err;
@@ -189,7 +189,7 @@ static int ge_eth_reader_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
 }
 
 static int ge_eth_writer_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
-    int rv;
+    int err, rv;
     struct sockaddr_in addr;
 
     ctx->sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -203,7 +203,7 @@ static int ge_eth_writer_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     addr.sin_port = htons(param->port);
     rv = connect(ctx->sock, (const struct sockaddr*) &addr, sizeof(addr));
     if (rv < 0) {
-        int err = errno;
+        err = errno;
         close(ctx->sock);
         ctx->sock = -1;
         errno = err;

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -113,16 +113,17 @@ int pirate_mercury_parse_param(char *str, pirate_mercury_param_t *param) {
 }
 
 int pirate_mercury_open(int gd, int flags, pirate_mercury_param_t *param, mercury_ctx *ctx) {
-    int rv = -1;
+    int err, rv = -1;
 
 
     pirate_mercury_init_param(gd, param);
     // Current implementation uses pipe as a loopback
     // Remove pipe creation once it is no longer needed
+    err = errno;
     rv = mkfifo(param->path, 0660);
     if (rv == -1) {
         if (errno == EEXIST) {
-            errno = 0;
+            errno = err;
         } else {
             return -1;
         }

--- a/libpirate/pipe.c
+++ b/libpirate/pipe.c
@@ -51,10 +51,12 @@ int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param) {
 
 int pirate_pipe_open(int gd, int flags, pirate_pipe_param_t *param,
                         pipe_ctx *ctx) {
+    int err;
     pirate_pipe_init_param(gd, param);
+    err = errno;
     if (mkfifo(param->path, 0660) == -1) {
         if (errno == EEXIST) {
-            errno = 0;
+            errno = err;
         } else {
             return -1;
         }

--- a/libpirate/shmem.c
+++ b/libpirate/shmem.c
@@ -65,8 +65,7 @@ static inline int is_full(uint64_t value) {
 }
 
 static shmem_buffer_t *shmem_buffer_init(int fd, int buffer_size) {
-    int rv;
-    int err;
+    int err, rv;
     int success = 0;
     shmem_buffer_t *shmem_buffer = NULL;
     pthread_mutexattr_t mutex_attr;
@@ -256,10 +255,10 @@ int shmem_buffer_open(int gd, int flags, pirate_shmem_param_t *param, shmem_ctx 
             goto error;
         }
     }
-    
+    err = errno;
     if (shm_unlink(param->path) == -1) {
         if (errno == ENOENT) {
-            errno = 0;
+            errno = err;
         } else {
             goto error;
         }

--- a/libpirate/udp_shmem.c
+++ b/libpirate/udp_shmem.c
@@ -306,10 +306,11 @@ int udp_shmem_buffer_open(int gd, int flags, pirate_udp_shmem_param_t *param, ud
             atomic_store(&buf->writer_pid, 0);
             goto error;
         }
-  }
+    }
+    err = errno;
     if (shm_unlink(param->path) == -1) {
         if (errno == ENOENT) {
-            errno = 0;
+            errno = err;
         } else {
             goto error;
         }

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -61,7 +61,7 @@ int pirate_udp_socket_parse_param(char *str, pirate_udp_socket_param_t *param) {
 }
 
 static int udp_socket_reader_open(pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
-    int rv;
+    int err, rv;
     struct sockaddr_in addr;
 
     ctx->sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -77,7 +77,7 @@ static int udp_socket_reader_open(pirate_udp_socket_param_t *param, udp_socket_c
     int enable = 1;
     rv = setsockopt(ctx->sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
     if (rv < 0) {
-        int err = errno;
+        err = errno;
         close(ctx->sock);
         ctx->sock = -1;
         errno = err;
@@ -89,7 +89,7 @@ static int udp_socket_reader_open(pirate_udp_socket_param_t *param, udp_socket_c
                         &param->buffer_size,
                         sizeof(param->buffer_size));
         if (rv < 0) {
-            int err = errno;
+            err = errno;
             close(ctx->sock);
             ctx->sock = -1;
             errno = err;
@@ -99,7 +99,7 @@ static int udp_socket_reader_open(pirate_udp_socket_param_t *param, udp_socket_c
 
     rv = bind(ctx->sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in));
     if (rv < 0) {
-        int err = errno;
+        err = errno;
         close(ctx->sock);
         ctx->sock = -1;
         errno = err;
@@ -110,7 +110,7 @@ static int udp_socket_reader_open(pirate_udp_socket_param_t *param, udp_socket_c
 }
 
 static int udp_socket_writer_open(pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
-    int rv;
+    int err, rv;
     struct sockaddr_in addr;
 
     ctx->sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -123,7 +123,7 @@ static int udp_socket_writer_open(pirate_udp_socket_param_t *param, udp_socket_c
                         &param->buffer_size,
                         sizeof(param->buffer_size));
         if (rv < 0) {
-            int err = errno;
+            err = errno;
             close(ctx->sock);
             ctx->sock = -1;
             errno = err;
@@ -137,7 +137,7 @@ static int udp_socket_writer_open(pirate_udp_socket_param_t *param, udp_socket_c
     addr.sin_port = htons(param->port);
     rv = connect(ctx->sock, (const struct sockaddr*) &addr, sizeof(addr));
     if (rv < 0) {
-        int err = errno;
+        err = errno;
         close(ctx->sock);
         ctx->sock = -1;
         errno = err;


### PR DESCRIPTION
When ignoring the error status of a system call, restore the previous value of errno. Do not reset the errno to 0.