### PR TITLE
Set default value of GAPS_ENABLE to empty string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,10 @@ jobs:
         mkdir -p build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=../dist/libpirate \
-              -DGTEST_ROOT:PATH=$HOME/googletest -DPIRATE_UNIT_TEST=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+              -DGTEST_ROOT:PATH=$HOME/googletest -DPIRATE_UNIT_TEST=ON \
+              -DGAPS_ENABLE=OFF \
+              -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+              ..
         make
         make install
     - name: Make libpirate artifact
@@ -41,7 +44,7 @@ jobs:
     - name: build demos
       run: |
         cd build
-        cmake -DGAPS_DEMOS=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+        cmake -DGAPS_DEMOS=ON -DGAPS_ENABLE=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
         make
     - name: time_demo tests
       run: |
@@ -91,7 +94,11 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -DGTEST_ROOT:PATH=$HOME/googletest -DPIRATE_UNIT_TEST=ON -DPIRATE_SHMEM_FEATURE=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+        cmake -DGTEST_ROOT:PATH=$HOME/googletest -DPIRATE_UNIT_TEST=ON \
+              -DPIRATE_SHMEM_FEATURE=ON \
+              -DGAPS_ENABLE=OFF \
+              -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+              ..
         make
     - name: libpirate tests
       timeout-minutes: 1
@@ -135,8 +142,8 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -DGTEST_ROOT:PATH=$HOME/googletest \
-              -DGAPS_ENABLE=ON -DPIRATE_UNIT_TEST=ON \
+        cmake -DGTEST_ROOT:PATH=$HOME/googletest -DPIRATE_UNIT_TEST=ON \
+              -DGAPS_ENABLE=ON \
               -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
               ..
         make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif(NOT CMAKE_C_COMPILER)
 project(gaps)
 
 # Common options
-option(GAPS_ENABLE "Enable compilation with GAPS annotation" OFF)
+set(GAPS_ENABLE "" CACHE STRING "Enable compilation with pirate annotations")
 option(SINGLE_BINARY "Create a single binary across enclaves" OFF)
 option(PIRATE_SHMEM_FEATURE "support shared memory channels" OFF)
 option(PIRATE_UNIT_TEST "Enable compilation of PIRATE unit tests" OFF)
@@ -28,6 +28,17 @@ endif(BUILD_ALL)
 
 # Common build options
 set(PIRATE_C_FLAGS -Werror -Wall -Wextra -Wpedantic -fPIC)
+
+if("${GAPS_ENABLE}" STREQUAL "")
+    message("-- Testing for pirate annotation support")
+    try_compile(GAPS_ENABLE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/test_gaps.c)
+endif("${GAPS_ENABLE}" STREQUAL "")
+
+if (GAPS_ENABLE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGAPS_ENABLE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGAPS_ENABLE")
+    set(PIRATE_C_FLAGS ${PIRATE_C_FLAGS} "-ffunction-sections" "-fdata-sections" "--target=x86_64-pc-linux-elf")
+endif(GAPS_ENABLE)
 
 set(PIRATE_STATIC_LIB libpirate_static)
 set(PIRATE_SHARED_LIB libpirate_shared)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ cmake -D<OPTION_NAME>=ON ..
 ```
 
  * ```PIRATE_UNIT_TEST``` enable compilation of libpirate unit tests (requires googletest v1.10 or greater)
- * ```GAPS_ENABLE``` enable compilation with GAPS annotations
+ * ```GAPS_ENABLE``` enable compilation with pirate annotations. If not defined then test compiler annotation support.
  * ```CHANNEL_DEMO``` enable compilation of GAPS channel application
  * ```GAPS_DEMOS``` enable compilation of all GAPS demo applications
  * ```GAPS_BENCH``` enable compilation of GAPS benchmark applications

--- a/cmake/test_gaps.c
+++ b/cmake/test_gaps.c
@@ -1,0 +1,4 @@
+#ifndef __GAPS__
+#error "No GAPS extensions found"
+#endif
+int main(void) {}

--- a/demos/channel_demo/CMakeLists.txt
+++ b/demos/channel_demo/CMakeLists.txt
@@ -6,7 +6,7 @@ set(VERSION 0.0.1)
 set(CMAKE_BUILD_TYPE RelwithDebInfo)
 
 # Build flags
-SET(BUILD_FLAGS ${PIRATE_C_FLAGS} "-O0" "-g")
+SET(BUILD_FLAGS ${PIRATE_C_FLAGS})
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEMO_VERSION='\"${VERSION}\"'")
 
 # Common

--- a/demos/cxx_demo/CMakeLists.txt
+++ b/demos/cxx_demo/CMakeLists.txt
@@ -3,19 +3,11 @@ cmake_minimum_required(VERSION 3.13)
 project(cxx_demo)
 set(CMAKE_BUILD_TYPE RelwithDebInfo)
 
-# Options
-if (GAPS_ENABLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGAPS_ENABLE")
-endif(GAPS_ENABLE)
-
 # Dependencies
 include_directories(../../libpirate)
 
 # Build flags
-set(BUILD_FLAGS "-Werror" "-Wall" "-Wextra" "-Wpedantic" "-O3")
-if (GAPS_ENABLE)
-    set(BUILD_FLAGS ${BUILD_FLAGS} "-ffunction-sections" "-fdata-sections" "--target=x86_64-pc-linux-elf")
-endif(GAPS_ENABLE)
+SET(BUILD_FLAGS ${PIRATE_C_FLAGS})
 
 SET(READER_TGT reader_cxx)
 SET(WRITER_TGT writer_cxx)

--- a/demos/enclave_demo/CMakeLists.txt
+++ b/demos/enclave_demo/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(enclave_demo)
 
+SET(BUILD_FLAGS ${PIRATE_C_FLAGS})
+
 function(add_gaps_target TGT SRC)
-    SET(BUILD_FLAGS "-Werror" "-Wall" "-Wextra" "-Wpedantic" "-O3" "-ffunction-sections" "-fdata-sections" "--target=x86_64-pc-linux-elf")
     add_executable(${TGT} ${SRC})
     target_compile_options(${TGT} PRIVATE ${BUILD_FLAGS})
     target_link_options(${TGT} PRIVATE "LINKER:-enclave" "LINKER:${TGT}" "-fuse-ld=lld")

--- a/demos/simple_demo/CMakeLists.txt
+++ b/demos/simple_demo/CMakeLists.txt
@@ -3,11 +3,6 @@ cmake_minimum_required(VERSION 3.13)
 project(simple_demo)
 set(CMAKE_BUILD_TYPE RelwithDebInfo)
 
-# Options
-if (GAPS_ENABLE)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGAPS_ENABLE")
-endif(GAPS_ENABLE)
-
 # Sensitivity levels and output binary names
 set(HIGH "high")
 set(LOW "low")
@@ -28,10 +23,7 @@ configure_file(${RES_DIR}/${FAV_ICON_HIGH} ${HIGH_DIR}/${FAV_ICON} COPYONLY)
 configure_file(${RES_DIR}/${FAV_ICON_LOW} ${LOW_DIR}/${FAV_ICON} COPYONLY)
 
 # Build flags
-set(BUILD_FLAGS "-Werror" "-Wall" "-Wextra" "-Wpedantic" "-O3")
-if (GAPS_ENABLE)
-    set(BUILD_FLAGS ${BUILD_FLAGS} "-ffunction-sections" "-fdata-sections" "--target=x86_64-pc-linux-elf")
-endif(GAPS_ENABLE)
+SET(BUILD_FLAGS ${PIRATE_C_FLAGS})
 
 # Source files
 SET(SRC_DIR ${PROJECT_SOURCE_DIR}/src)

--- a/demos/time_demo/CMakeLists.txt
+++ b/demos/time_demo/CMakeLists.txt
@@ -14,10 +14,6 @@ if(GAPS_SERIAL)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGAPS_SERIAL")
 endif(GAPS_SERIAL)
 
-if (GAPS_ENABLE)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGAPS_ENABLE")
-endif(GAPS_ENABLE)
-
 # Dependencies
 find_package(OpenSSL REQUIRED)
 find_library(JPEG_LIB jpeg)
@@ -51,10 +47,7 @@ set(PURPLE_DIR ${PROJECT_BINARY_DIR}/${LEVEL_PURPLE})
 file(MAKE_DIRECTORY ${ORANGE_DIR} ${YELLOW_DIR} ${PURPLE_DIR})
 
 # Build flags
-set(BUILD_FLAGS "-Werror" "-Wall" "-Wextra" "-Wpedantic" "-O3")
-if (GAPS_ENABLE)
-    set(BUILD_FLAGS ${BUILD_FLAGS} "-ffunction-sections" "-fdata-sections" "--target=x86_64-pc-linux-elf")
-endif(GAPS_ENABLE)
+SET(BUILD_FLAGS ${PIRATE_C_FLAGS})
 
 # Source files
 set(COMMON_SRC


### PR DESCRIPTION
Test the C compiler for pirate annotations if GAPS_ENABLE is not defined. Update the CI jobs to explicitly enable or disable annotation support.