### PR TITLE
Move uio into the SHMEM_BUFFER optional compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
+include(CheckIncludeFile)
 
 # This must be done before any language is set (ie before any project() or
 # enable_language() command).
@@ -38,6 +39,11 @@ if (PIRATE_SHMEM_FEATURE)
     SET(PIRATE_C_FLAGS ${PIRATE_C_FLAGS} -mavx2)
     set(PIRATE_APP_LIBS ${PIRATE_APP_LIBS} rt)
 endif(PIRATE_SHMEM_FEATURE)
+
+CHECK_INCLUDE_FILE(stdatomic.h HAVE_STD_ATOMIC)
+if (HAVE_STD_ATOMIC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_STD_ATOMIC")
+endif(HAVE_STD_ATOMIC)
 
 add_subdirectory(libpirate)
 

--- a/libpirate/CMakeLists.txt
+++ b/libpirate/CMakeLists.txt
@@ -16,12 +16,12 @@ SET(PIRATE_SOURCES
     "tcp_socket.c"
     "udp_socket.c"
     "unix_socket.c"
-    "uio.c"
+    "uio_interface.c"
 )
 
 if(PIRATE_SHMEM_FEATURE)
     add_definitions(-DPIRATE_SHMEM_FEATURE=1)
-    set(PIRATE_SOURCES ${PIRATE_SOURCES} "shmem.c" "udp_shmem.c" "checksum.c")
+    set(PIRATE_SOURCES ${PIRATE_SOURCES} "shmem.c" "uio.c" "udp_shmem.c" "checksum.c")
 endif(PIRATE_SHMEM_FEATURE)
 
 include_directories(.)

--- a/libpirate/shmem_buffer.h
+++ b/libpirate/shmem_buffer.h
@@ -24,8 +24,12 @@
 #ifdef __cplusplus
 #include <atomic>
 using namespace std;
-#else
+#elif HAVE_STD_ATOMIC
 #include <stdatomic.h>
+#else
+// This is a workaround.
+// Do not use shmem_buffer_t when atomics are not available
+typedef uint_fast64_t atomic_uint_fast64_t;
 #endif
 
 typedef struct {

--- a/libpirate/test/uio_test.cpp
+++ b/libpirate/test/uio_test.cpp
@@ -22,13 +22,13 @@ namespace GAPS
 TEST(ChannelUioTest, ConfigurationParser) {
     int rv;
     pirate_channel_param_t param;
-    const pirate_uio_param_t *uio_param = &param.channel.uio;
 
     char opt[128];
     const char *name = "uio";
     const char *path = "/tmp/test_uio";
 
 #if PIRATE_SHMEM_FEATURE
+    const pirate_uio_param_t *uio_param = &param.channel.uio;
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
     ASSERT_EQ(0, rv);

--- a/libpirate/test/uio_test.cpp
+++ b/libpirate/test/uio_test.cpp
@@ -28,6 +28,7 @@ TEST(ChannelUioTest, ConfigurationParser) {
     const char *name = "uio";
     const char *path = "/tmp/test_uio";
 
+#if PIRATE_SHMEM_FEATURE
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
     ASSERT_EQ(0, rv);
@@ -41,8 +42,16 @@ TEST(ChannelUioTest, ConfigurationParser) {
     ASSERT_EQ(0, errno);
     ASSERT_EQ(UIO_DEVICE, param.channel_type);
     ASSERT_STREQ(path, uio_param->path);
+#else
+    snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
+    rv = pirate_parse_channel_param(opt, &param);
+    ASSERT_EQ(-1, rv);
+    ASSERT_EQ(ESOCKTNOSUPPORT, errno);
+    errno = 0;
+#endif
 }
 
+#if PIRATE_SHMEM_FEATURE
 class UioTest : public ChannelTest
 {
 public:
@@ -72,5 +81,5 @@ TEST_F(UioTest, UioFunctionalTest)
         errno = 0;
     }
 }
-
+#endif
 } // namespace

--- a/libpirate/uio.c
+++ b/libpirate/uio.c
@@ -70,7 +70,7 @@ static void pirate_uio_init_param(pirate_uio_param_t *param) {
     }
 }
 
-int pirate_uio_parse_param(char *str, pirate_uio_param_t *param) {
+int pirate_internal_uio_parse_param(char *str, pirate_uio_param_t *param) {
     char *ptr = NULL;
 
     if (((ptr = strtok(str, OPT_DELIM)) == NULL) ||
@@ -98,7 +98,7 @@ static shmem_buffer_t *uio_buffer_init(int gd, int fd) {
     return uio_buffer;
 }
 
-int pirate_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
+int pirate_internal_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
@@ -152,7 +152,7 @@ error:
     return -1;
 }
 
-int pirate_uio_close(uio_ctx *ctx) {
+int pirate_internal_uio_close(uio_ctx *ctx) {
     shmem_buffer_t* buf = ctx->buf;
     if (buf == NULL) {
         errno = EBADF;
@@ -170,7 +170,7 @@ int pirate_uio_close(uio_ctx *ctx) {
     return munmap(buf, buffer_size());
 }
 
-ssize_t pirate_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buffer, size_t count) {
+ssize_t pirate_internal_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buffer, size_t count) {
     (void) param;
     uint64_t position;
     uint32_t reader, writer;
@@ -227,7 +227,7 @@ ssize_t pirate_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf
     return nbytes;
 }
 
-ssize_t pirate_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buffer, size_t count) {
+ssize_t pirate_internal_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buffer, size_t count) {
     (void) param;
     int buffer_size;
     size_t nbytes, nbytes1, nbytes2;

--- a/libpirate/uio.h
+++ b/libpirate/uio.h
@@ -16,19 +16,12 @@
 #ifndef __PIRATE_CHANNEL_UIO_H
 #define __PIRATE_CHANNEL_UIO_H
 
-#include "libpirate.h"
-#include "shmem_buffer.h"
+#include "uio_interface.h"
 
-typedef struct {
-    int fd;
-    int flags;
-    shmem_buffer_t *buf;
-} uio_ctx;
-
-int pirate_uio_parse_param(char *str, pirate_uio_param_t *param);
-int pirate_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx);
-int pirate_uio_close(uio_ctx *ctx);
-ssize_t pirate_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count);
-ssize_t pirate_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf, size_t count);
+int pirate_internal_uio_parse_param(char *str, pirate_uio_param_t *param);
+int pirate_internal_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx);
+int pirate_internal_uio_close(uio_ctx *ctx);
+ssize_t pirate_internal_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count);
+ssize_t pirate_internal_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf, size_t count);
 
 #endif /* __PIRATE_CHANNEL_UIO_H */

--- a/libpirate/uio_interface.c
+++ b/libpirate/uio_interface.c
@@ -1,0 +1,70 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include "uio_interface.h"
+#include "uio.h"
+
+int pirate_uio_parse_param(char *str, pirate_uio_param_t *param) {
+#if PIRATE_SHMEM_FEATURE
+    return pirate_internal_uio_parse_param(str, param);
+#else
+    (void) str, (void) param;
+    errno = ESOCKTNOSUPPORT;
+    return -1;
+#endif
+}
+
+int pirate_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
+#ifdef PIRATE_SHMEM_FEATURE
+    return pirate_internal_uio_open(gd, flags, param, ctx);
+#else
+    (void) gd, (void) flags, (void) param, (void) ctx;
+    errno = ESOCKTNOSUPPORT;
+    return -1;
+#endif
+}
+
+int pirate_uio_close(uio_ctx *ctx) {
+#ifdef PIRATE_SHMEM_FEATURE
+    return pirate_internal_uio_close(ctx);
+#else
+    (void) ctx;
+    errno = ESOCKTNOSUPPORT;
+    return -1;
+#endif
+}
+
+ssize_t pirate_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count) {
+#ifdef PIRATE_SHMEM_FEATURE
+    return pirate_internal_uio_read(param, ctx, buf, count);
+#else
+    (void) param, (void) ctx, (void) buf, (void) count;
+    errno = ESOCKTNOSUPPORT;
+    return -1;
+#endif
+}
+
+ssize_t pirate_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf,
+                            size_t count) {
+#ifdef PIRATE_SHMEM_FEATURE
+    return pirate_internal_uio_write(param, ctx, buf, count);
+#else
+    (void) param, (void) ctx, (void) buf, (void) count;
+    errno = ESOCKTNOSUPPORT;
+    return -1;
+#endif
+}

--- a/libpirate/uio_interface.h
+++ b/libpirate/uio_interface.h
@@ -1,0 +1,34 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2019 Two Six Labs, LLC.  All rights reserved.
+ */
+
+#ifndef __PIRATE_CHANNEL_UIO_INTERFACE_H
+#define __PIRATE_CHANNEL_UIO_INTERFACE_H
+
+#include "libpirate.h"
+#include "shmem_buffer.h"
+
+typedef struct {
+    int fd;
+    int flags;
+    shmem_buffer_t *buf;
+} uio_ctx;
+
+int pirate_uio_parse_param(char *str, pirate_uio_param_t *param);
+int pirate_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx);
+int pirate_uio_close(uio_ctx *ctx);
+ssize_t pirate_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count);
+ssize_t pirate_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf, size_t count);
+
+#endif /* __PIRATE_CHANNEL_UIO_INTERFACE_H */


### PR DESCRIPTION
Do not compile channel types that use atomic operations when atomic operations are not available.