### PR TITLE
Replace INADDR_ANY with ip address parameter

### DIFF
--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -163,7 +163,7 @@ static int ge_eth_reader_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
 
     memset(&addr, 0, sizeof(struct sockaddr_in));
     addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr.s_addr = inet_addr(param->addr);
     addr.sin_port = htons(param->port);
 
     int enable = 1;

--- a/libpirate/tcp_socket.c
+++ b/libpirate/tcp_socket.c
@@ -74,7 +74,7 @@ static int tcp_socket_reader_open(pirate_tcp_socket_param_t *param, tcp_socket_c
 
     memset(&addr, 0, sizeof(struct sockaddr_in));
     addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr.s_addr = inet_addr(param->addr);
     addr.sin_port = htons(param->port);
 
     int enable = 1;

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -71,7 +71,7 @@ static int udp_socket_reader_open(pirate_udp_socket_param_t *param, udp_socket_c
 
     memset(&addr, 0, sizeof(struct sockaddr_in));
     addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr.s_addr = inet_addr(param->addr);
     addr.sin_port = htons(param->port);
 
     int enable = 1;


### PR DESCRIPTION
Bind the IP-based channels to a the ip address passed in as a parameter. This allows the reader to identify an attempt to bind to an address that cannot be assigned. Here is the error condition that is now detected by the channel demo:

```
./reader -l 10,20,1 -C ge_eth,169.254.0.1,8888 -v
[2020-03-16 15:17:13.198249] INFO Starting the reader
[2020-03-16 15:17:13.198598] ERR  Failed to open GAPS channel (Cannot assign requested address)
reader: Failed to initialize channel ge_eth,169.254.0.1,8888
```