### PR TITLE
Deterministic ngc demo

### DIFF
--- a/demos/pnt_demo/2.channel/pnt_example.cpp
+++ b/demos/pnt_demo/2.channel/pnt_example.cpp
@@ -34,7 +34,6 @@ int main()
 
   // setup the dataflow relationships
   gpsData.addListener([uav](const Position& p) { uav->onGpsPositionChange(p); });
-  gpsData.addListener([tgt](const Position& p) { tgt->onGpsPositionChange(p); });
   uavData.addListener([tgt](const Position& p) { tgt->setUAVLocation(p); });
   rfData.addListener( [tgt](const Distance& d) { tgt->setDistance(d); });
 

--- a/demos/pnt_demo/2.channel/target.cpp
+++ b/demos/pnt_demo/2.channel/target.cpp
@@ -2,17 +2,23 @@
 #include "ownship.h"
 #include "sensors.h"
 
-void Target::onGpsPositionChange(const Position& p) {  
-  bool tick = false;
-  		
-  if (_cycle != 0 && 0 == ++_cnt % _cycle) {
-    targetLocation();
-    print_track();
-  }
+void Target::setDistance(Distance const& d) {
+  _d_cnt++;
+  _d = d;
+  targetLocation();
+}
+
+void Target::setUAVLocation(Position const& p) {
+  _uav_pos_cnt++;
+  _uav_pos = p;
+  targetLocation();
 }
 
 void Target::targetLocation() {
-  _track._pos._x = _uav_pos._x + _d._dx;
-  _track._pos._y = _uav_pos._y + _d._dy;
-  _track._pos._z = _uav_pos._z + _d._dz;
+  if ((_uav_pos_cnt == _d_cnt) && (0 == ++_cnt % _cycle)) {
+    _track._pos._x = _uav_pos._x + _d._dx;
+    _track._pos._y = _uav_pos._y + _d._dy;
+    _track._pos._z = _uav_pos._z + _d._dz;
+    print_track();
+  }
 }

--- a/demos/pnt_demo/2.channel/target.h
+++ b/demos/pnt_demo/2.channel/target.h
@@ -20,8 +20,6 @@ public:
   ~Target() {};
 
   Track getTracking() { return _track; }
-  
-  void onGpsPositionChange(const Position& p);
 
   void print_track() {
     std::cout << "\t\t--- Target TRACK ---" << std::endl

--- a/demos/pnt_demo/2.channel/target.h
+++ b/demos/pnt_demo/2.channel/target.h
@@ -10,10 +10,10 @@ public:
   Track _track;
   int _frequency;
   int _cycle;
-  int _cnt;
+  int _cnt, _d_cnt, _uav_pos_cnt;
 
 public:
-  Target(int rate = 1) : _frequency(rate) {
+  Target(int rate = 1) : _frequency(rate), _cnt(0), _d_cnt(0), _uav_pos_cnt(0) {
     _cycle = static_cast<int> (((1.0 / _frequency) / (sleep_msec / 1000)));
   };
 
@@ -29,9 +29,8 @@ public:
 	            << "\t\t y=" << _track._pos._y << std::endl
 	            << "\t\t z=" << _track._pos._z << std::endl << std::endl;
   }
-
-  void setDistance(Distance const& d)    { _d = d; }
-  void setUAVLocation(Position const& p) { _uav_pos = p; }
+  void setDistance(Distance const& d);
+  void setUAVLocation(Position const& p);
 private:
   void targetLocation();
 };

--- a/demos/pnt_demo/3.pipe/CMakeLists.txt
+++ b/demos/pnt_demo/3.pipe/CMakeLists.txt
@@ -11,6 +11,8 @@ add_executable(pnt
     pnt_example.cpp
 )
 
+target_link_libraries(pnt pthread)
+
 set_target_properties(pnt PROPERTIES
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED YES

--- a/demos/pnt_demo/3.pipe/Makefile
+++ b/demos/pnt_demo/3.pipe/Makefile
@@ -1,6 +1,6 @@
 CPPFLAGS=-std=c++17
 
 pnt: pnt_example.o ownship.o target.o
-	$(CXX) -o $@ $^
+	$(CXX) -o $@ $^ -lpthread
 clean:
 	rm -f pnt *.o

--- a/demos/pnt_demo/3.pipe/channel.h
+++ b/demos/pnt_demo/3.pipe/channel.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 #include <iostream>
 #include <sstream>
 #include <thread>

--- a/demos/pnt_demo/3.pipe/channel.h
+++ b/demos/pnt_demo/3.pipe/channel.h
@@ -73,7 +73,6 @@ void readMessages(int fd, std::function<void (const T& d)> f)
 template<typename T>
 void asyncReadMessages(Receiver<T> r, std::function<void (const T& d)> f) 
 {
-  std::cerr << "Async" << std::endl;
   std::thread t(&readMessages<T>, r.fd, f);
   t.detach();
 }

--- a/demos/pnt_demo/3.pipe/pnt_example.cpp
+++ b/demos/pnt_demo/3.pipe/pnt_example.cpp
@@ -2,6 +2,7 @@
 //
 
 #include <iostream>
+#include <mutex>
 #ifdef _WIN32
 # include <Windows.h>
 #else

--- a/demos/pnt_demo/3.pipe/pnt_example.cpp
+++ b/demos/pnt_demo/3.pipe/pnt_example.cpp
@@ -2,7 +2,6 @@
 //
 
 #include <iostream>
-#include <mutex>
 #ifdef _WIN32
 # include <Windows.h>
 #else

--- a/demos/pnt_demo/3.pipe/target.cpp
+++ b/demos/pnt_demo/3.pipe/target.cpp
@@ -2,17 +2,25 @@
 #include "ownship.h"
 #include "sensors.h"
 
-void Target::onGpsPositionChange(const Position& p) {  
-  bool tick = false;
-  		
-  if (_cycle != 0 && 0 == ++_cnt % _cycle) {
-    targetLocation();
-    print_track();
-  }
+void Target::setDistance(Distance const& d) {
+  std::lock_guard<std::mutex> guard(_mutex);
+  _d_cnt++;
+  _d = d;
+  targetLocation();
+}
+
+void Target::setUAVLocation(Position const& p) {
+  std::lock_guard<std::mutex> guard(_mutex);
+  _uav_pos_cnt++;
+  _uav_pos = p;
+  targetLocation();
 }
 
 void Target::targetLocation() {
-  _track._pos._x = _uav_pos._x + _d._dx;
-  _track._pos._y = _uav_pos._y + _d._dy;
-  _track._pos._z = _uav_pos._z + _d._dz;
+  if ((_uav_pos_cnt == _d_cnt) && (0 == ++_cnt % _cycle)) {
+    _track._pos._x = _uav_pos._x + _d._dx;
+    _track._pos._y = _uav_pos._y + _d._dy;
+    _track._pos._z = _uav_pos._z + _d._dz;
+    print_track();
+  }
 }

--- a/demos/pnt_demo/3.pipe/target.h
+++ b/demos/pnt_demo/3.pipe/target.h
@@ -1,29 +1,28 @@
 #pragma once
 #include "channel.h"
 #include "pnt_data.h"
-#include <iostream> 
-
+#include <iostream>
+#include <mutex>
 
 class Target
 {
-public:
+private:
+  std::mutex _mutex;
   Distance  _d;
   Position _uav_pos;
   Track _track;
   int _frequency;
   int _cycle;
-  int _cnt;
+  int _cnt, _d_cnt, _uav_pos_cnt;
 
 public:
-  Target(int rate = 1) : _frequency(rate) {
+  Target(int rate = 1) : _frequency(rate), _cnt(0), _d_cnt(0), _uav_pos_cnt(0) {
     _cycle = static_cast<int> (((1.0 / _frequency) / (sleep_msec / 1000)));
   };
 
   ~Target() {};
 
   Track getTracking() { return _track; }
-  
-  void onGpsPositionChange(const Position& p);
 
   void print_track() {
     print([this](std::ostream& o) {
@@ -33,10 +32,8 @@ public:
 	      << "\t\t z=" << _track._pos._z << std::endl << std::endl;
     });
   }
-
-  void setDistance(Distance const& d)    { _d = d; }
-  void setUAVLocation(Position const& p) { _uav_pos = p; }
+  void setDistance(Distance const& d);
+  void setUAVLocation(Position const& p);
 private:
   void targetLocation();
 };
-

--- a/demos/pnt_demo/4.pirate/channel.h
+++ b/demos/pnt_demo/4.pirate/channel.h
@@ -1,6 +1,19 @@
 #pragma once
 #include <functional>
+#include <iostream>
+#include <sstream>
 #include <thread>
+#include <unistd.h>
+
+// This prints out the string written to ostream in a single
+// system call.
+inline
+void print(std::function<void(std::ostream& o)> p) {
+  std::stringstream o;
+  p(o);
+  std::string s=o.str();
+  write(STDOUT_FILENO, s.c_str(), s.size());  
+}
 
 template<typename T>
 class Sender {

--- a/demos/pnt_demo/4.pirate/ownship.h
+++ b/demos/pnt_demo/4.pirate/ownship.h
@@ -27,10 +27,12 @@ public:
 
   void print_track()
   {
-    std::cout << "---UAV TRACK ---" << std::endl
+    print([this](std::ostream& o) {
+      o << "---UAV TRACK ---" << std::endl
 	      << " x=" << _track._pos._x << std::endl
 	      << " y=" << _track._pos._y << std::endl
 	      << " z=" << _track._pos._z << std::endl << std::endl;
+    });
   }
 protected:
   void setPosition(Position const& p) { _track._pos = p; }

--- a/demos/pnt_demo/4.pirate/pnt_example.cpp
+++ b/demos/pnt_demo/4.pirate/pnt_example.cpp
@@ -68,24 +68,22 @@ int run_green(int argc, char** argv) PIRATE_ENCLAVE_MAIN("green")
   }
 
   // Create channels
-//  piratePipe(gpsToTarget, 0);
-//  auto gpsToTargetSend = gdSender<Position>(gpsToTarget, 0);            // Green to green
-//  auto gpsToTargetRecv = gdReceiver<Position>(gpsToTarget, 0);          // Green to green
-  auto gpsToUAVSend    = pirateSender<Position>(gpsToUAVPath, 0);       // Green to orange
-  auto uavToTargetRecv = pirateReceiver<Position>(uavToTargetPath, 1);  // Orange to green
-  auto rfToTargetRecv  = pirateReceiver<Distance>(rfToTargetPath, 2);   // Orange to green
-
-  // Function to call when gps changes to update target.
-  std::function<void(Position)> onGPSChange;
+  piratePipe(gpsToTarget, 0);
+  auto gpsToTargetSend = gdSender<Position>(gpsToTarget, 0);            // Green to green
+  auto gpsToTargetRecv = gdReceiver<Position>(gpsToTarget, 0);          // Green to green
+  auto gpsToUAVSend    = pirateSender<Position>(gpsToUAVPath, 1);       // Green to orange
+  auto uavToTargetRecv = pirateReceiver<Position>(uavToTargetPath, 2);  // Orange to green
+  auto rfToTargetRecv  = pirateReceiver<Distance>(rfToTargetPath, 3);   // Orange to green
 
   // Setup sender for gps that broadcasts to two other channels.
   Sender<Position> gpsSender(
-        [&onGPSChange, gpsToUAVSend](const Position& p) {
-          onGPSChange(p);
+        [gpsToUAVSend, gpsToTargetSend](const Position& p) {
           gpsToUAVSend(p);
+          gpsToTargetSend(p);
         },
-        [&gpsToUAVSend]() {
+        [&gpsToUAVSend, &gpsToTargetSend]() {
           gpsToUAVSend.close();
+          gpsToTargetSend.close();
         });
 
   Time start;
@@ -109,11 +107,12 @@ int run_green(int argc, char** argv) PIRATE_ENCLAVE_MAIN("green")
         std::lock_guard<std::mutex> g(tgtMutex);
         tgt.setDistance(d);
       });
-  onGPSChange = 
-    [&tgt, &tgtMutex](const Position& p) {
+  auto gpsToTargetThread =
+    asyncReadMessages<Position>(gpsToTargetRecv,
+      [&tgt, &tgtMutex](const Position& p) {
         std::lock_guard<std::mutex> g(tgtMutex);
         tgt.onGpsPositionChange(p);
-      };
+      });
 
   // Run every 10 gps milliseconds.
   onTimer(start, duration,std::chrono::milliseconds(10), 
@@ -125,6 +124,7 @@ int run_green(int argc, char** argv) PIRATE_ENCLAVE_MAIN("green")
   // Wait for all target threads to terminate.
   uavToTargetThread.join();
   rfToTargetThread.join();
+  gpsToTargetThread.join();
   return 0;
 }
 

--- a/demos/pnt_demo/4.pirate/target.cpp
+++ b/demos/pnt_demo/4.pirate/target.cpp
@@ -1,16 +1,26 @@
 #include "target.h"
+#include "ownship.h"
+#include "sensors.h"
 
-void Target::onGpsPositionChange(const Position& p) {  
-  static int cnt = 0;
-  		
-  if (_cycle != 0 && 0 == ++cnt % _cycle) {
-    targetLocation();
-    print_track();
-  }
+void Target::setDistance(Distance const& d) {
+  std::lock_guard<std::mutex> guard(_mutex);
+  _d_cnt++;
+  _d = d;
+  targetLocation();
+}
+
+void Target::setUAVLocation(Position const& p) {
+  std::lock_guard<std::mutex> guard(_mutex);
+  _uav_pos_cnt++;
+  _uav_pos = p;
+  targetLocation();
 }
 
 void Target::targetLocation() {
-  _track._pos._x = _uav_pos._x + _d._dx;
-  _track._pos._y = _uav_pos._y + _d._dy;
-  _track._pos._z = _uav_pos._z + _d._dz;
+  if ((_uav_pos_cnt == _d_cnt) && (0 == ++_cnt % _cycle)) {
+    _track._pos._x = _uav_pos._x + _d._dx;
+    _track._pos._y = _uav_pos._y + _d._dy;
+    _track._pos._z = _uav_pos._z + _d._dz;
+    print_track();
+  }
 }

--- a/demos/pnt_demo/4.pirate/target.h
+++ b/demos/pnt_demo/4.pirate/target.h
@@ -1,40 +1,39 @@
 #pragma once
 #include "channel.h"
 #include "pnt_data.h"
-#include <iostream> 
-
+#include <iostream>
+#include <mutex>
 
 class Target
 {
-public:
+private:
+  std::mutex _mutex;
   Distance  _d;
   Position _uav_pos;
   Track _track;
   int _frequency;
   int _cycle;
+  int _cnt, _d_cnt, _uav_pos_cnt;
 
 public:
-  Target(int rate = 1) : _frequency(rate) {
+  Target(int rate = 1) : _frequency(rate), _cnt(0), _d_cnt(0), _uav_pos_cnt(0) {
     _cycle = static_cast<int> (((1.0 / _frequency) / (sleep_msec / 1000)));
   };
+
   ~Target() {};
 
   Track getTracking() { return _track; }
-  
-  // Update function when GPS position has changed.
-  void onGpsPositionChange(const Position& p);
 
   void print_track() {
-    std::cout << "\t\t--- Target TRACK ---" << std::endl
+    print([this](std::ostream& o) {
+      o << "\t\t--- Target TRACK ---" << std::endl
 	      << "\t\t x=" << _track._pos._x << std::endl
 	      << "\t\t y=" << _track._pos._y << std::endl
 	      << "\t\t z=" << _track._pos._z << std::endl << std::endl;
+    });
   }
-
-  // Previously, protected, now public
-  void setDistance(Distance const& d)    { _d = d; }
-  void setUAVLocation(Position const& p) { _uav_pos = p; }
+  void setDistance(Distance const& d);
+  void setUAVLocation(Position const& p);
 private:
   void targetLocation();
 };
-

--- a/demos/pnt_demo/4.pirate/timer.cpp
+++ b/demos/pnt_demo/4.pirate/timer.cpp
@@ -19,7 +19,7 @@ void onTimer(TimerMsec start,
       now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now());
     }
   } else {  
-    TimerMsec now = start;
+    TimerMsec now = start + step;
     TimerMsec total = now + dur;
     while (now < total)
     {


### PR DESCRIPTION
This patch removes the event from the gps to the target. The event was creating a false dependency on the ordering of events. It was a false dependency because the updated information (the position parameter) being passed from gps to target was being dropped on the floor. Instead of the gps to target event, the target keeps a counter of the number of distance events and the number of uav position events it receives. When those counters are equal then update the current state of the target.

All four versions of the demo now produce the same deterministic output.