### PR TITLE
pirate open/close API change

### DIFF
--- a/demos/channel_demo/src/common.c
+++ b/demos/channel_demo/src/common.c
@@ -34,6 +34,8 @@
 #endif
 const char *argp_program_version = DEMO_VERSION;
 
+int gaps_channel;
+
 static const char *pattern_str(data_pattern_t p) {
     switch (p) {
         case ZEROS:
@@ -81,13 +83,8 @@ static int parse_channel_opt(char *str, int flags) {
         return rv;
     }
 
-    rv = pirate_set_channel_param(GAPS_CHANNEL, flags, &param);
-    if (rv != 0) {
-        log_msg(ERROR, "failed to set channel options '%s'", str);
-        return -1;
-    }
-
-    if (pirate_open(GAPS_CHANNEL, flags) != GAPS_CHANNEL) {
+    gaps_channel = pirate_open_param(&param, flags);
+    if (gaps_channel < 0) {
         log_msg(ERROR, "Failed to open GAPS channel");
         return -1;
     }

--- a/demos/channel_demo/src/common.h
+++ b/demos/channel_demo/src/common.h
@@ -19,8 +19,6 @@
 #include <argp.h>
 #include <stdint.h>
 
-#define GAPS_CHANNEL 0
-
 #define OPT_DELIM ","
 
 /* Verbosity levels */

--- a/demos/channel_demo/src/reader.c
+++ b/demos/channel_demo/src/reader.c
@@ -21,6 +21,8 @@
 
 typedef channel_test_t reader_t;
 
+extern int gaps_channel;
+
 static struct argp_option options[] = {
     COMMON_OPTIONS,
     { NULL, 0, NULL, 0, NULL, 0 }
@@ -61,7 +63,7 @@ static int reader_init(reader_t *reader) {
 
 static int reader_term(reader_t *reader) {
     test_data_term(&reader->data);
-    return pirate_close(GAPS_CHANNEL, O_RDONLY);
+    return pirate_close(gaps_channel, O_RDONLY);
 }
 
 static int reader_run(reader_t *reader) {
@@ -87,7 +89,7 @@ static int reader_run(reader_t *reader) {
             }
         }
 
-        ssize_t rd_len = pirate_read(GAPS_CHANNEL, rd_buf, buf_len);
+        ssize_t rd_len = pirate_read(gaps_channel, rd_buf, buf_len);
         if (rd_len < 0) {
             log_msg(ERROR, "Failed to read GAPS data");
             rv = -1;

--- a/demos/channel_demo/src/reader.c
+++ b/demos/channel_demo/src/reader.c
@@ -63,7 +63,7 @@ static int reader_init(reader_t *reader) {
 
 static int reader_term(reader_t *reader) {
     test_data_term(&reader->data);
-    return pirate_close(gaps_channel, O_RDONLY);
+    return pirate_close(gaps_channel);
 }
 
 static int reader_run(reader_t *reader) {

--- a/demos/channel_demo/src/writer.c
+++ b/demos/channel_demo/src/writer.c
@@ -27,6 +27,8 @@ typedef struct {
     channel_test_t test;
 } writer_t;
 
+extern int gaps_channel;
+
 static struct argp_option options[] = {
     { "delay",   'd', "US",   0, "Inter-packet delay",               0 },
     COMMON_OPTIONS,
@@ -79,7 +81,7 @@ static int writer_init(writer_t *writer) {
 
 static int writer_term(writer_t *writer) {
     test_data_term(&writer->test.data);
-    return pirate_close(GAPS_CHANNEL, O_WRONLY);
+    return pirate_close(gaps_channel, O_WRONLY);
 }
 
 static int writer_run(writer_t *writer) {
@@ -101,7 +103,7 @@ static int writer_run(writer_t *writer) {
             }
         }
 
-        if (pirate_write(GAPS_CHANNEL, wr_buf, wr_len) != wr_len) {
+        if (pirate_write(gaps_channel, wr_buf, wr_len) != wr_len) {
             log_msg(ERROR, "Failed to write on GAPS channel");
             return -1;
         }

--- a/demos/channel_demo/src/writer.c
+++ b/demos/channel_demo/src/writer.c
@@ -81,7 +81,7 @@ static int writer_init(writer_t *writer) {
 
 static int writer_term(writer_t *writer) {
     test_data_term(&writer->test.data);
-    return pirate_close(gaps_channel, O_WRONLY);
+    return pirate_close(gaps_channel);
 }
 
 static int writer_run(writer_t *writer) {

--- a/demos/cxx_demo/reader.cpp
+++ b/demos/cxx_demo/reader.cpp
@@ -25,25 +25,19 @@
 static char buffer[BUF_SIZE];
 
 int main(int argc, char* argv[]) {
-    int rv, len;
+    int gd, rv, len;
     pirate_channel_param_t param;
 
     pirate_init_channel_param(PIPE, &param);
 
-    rv = pirate_set_channel_param(0, O_RDONLY, &param);
-    if (rv < 0) {
-        perror("pirate_init_channel_param");
-        return 1;
-    }
-
-    rv = pirate_open(0, O_RDONLY);
-    if (rv < 0) {
+    gd = pirate_open_param(&param, O_RDONLY);
+    if (gd < 0) {
         perror("pirate_open");
         return 1;
     }
 
     for (;;) {
-        rv = pirate_read(0, &len, sizeof(len));
+        rv = pirate_read(gd, &len, sizeof(len));
         if (rv != sizeof(len)) {
             std::cerr << "write error" << "\n";
             return 1;
@@ -51,7 +45,7 @@ int main(int argc, char* argv[]) {
         if (len == 0) {
             break;
         }
-        rv = pirate_read(0, buffer, len);
+        rv = pirate_read(gd, buffer, len);
         if (rv != len) {
             std::cerr << "write error" << "\n";
             return 1;

--- a/demos/cxx_demo/writer.cpp
+++ b/demos/cxx_demo/writer.cpp
@@ -25,19 +25,13 @@
 static char buffer[BUF_SIZE];
 
 int main(int argc, char* argv[]) {
-    int rv, len;
+    int gd, rv, len;
     pirate_channel_param_t param;
 
     pirate_init_channel_param(PIPE, &param);
 
-    rv = pirate_set_channel_param(0, O_WRONLY, &param);
-    if (rv < 0) {
-        perror("pirate_init_channel_param");
-        return 1;
-    }
-
-    rv = pirate_open(0, O_WRONLY);
-    if (rv < 0) {
+    gd = pirate_open_param(&param, O_WRONLY);
+    if (gd < 0) {
         perror("pirate_open");
         return 1;
     }
@@ -45,12 +39,12 @@ int main(int argc, char* argv[]) {
     while(std::cin.getline(buffer, BUF_SIZE)) {
         // send the terminating null byte
         len = strlen(buffer) + 1;
-        rv = pirate_write(0, &len, sizeof(len));
+        rv = pirate_write(gd, &len, sizeof(len));
         if (rv != sizeof(len)) {
             std::cerr << "write error" << "\n";
             return 1;
         }
-        rv = pirate_write(0, buffer, len);
+        rv = pirate_write(gd, buffer, len);
         if (rv != len) {
             std::cerr << "write error" << "\n";
             return 1;
@@ -63,7 +57,7 @@ int main(int argc, char* argv[]) {
     }
 
     len = 0;
-    rv = pirate_write(0, &len, sizeof(len));
+    rv = pirate_write(gd, &len, sizeof(len));
     if (rv != sizeof(len)) {
         std::cerr << "write error" << "\n";
         return 1;

--- a/demos/pnt_demo/4.pirate/channel_fd.cpp
+++ b/demos/pnt_demo/4.pirate/channel_fd.cpp
@@ -17,24 +17,3 @@ void gdCheckedWrite(const std::string& config, int gd, const void* buf, size_t n
     exit(-1);
   }
 }
-
-void piratePipe(const std::string& config, int gd) {
-  pirate_channel_param_t param;
-
-  if (pirate_parse_channel_param(config.c_str(), &param) < 0) {
-    channel_errlog([config](FILE* f) { fprintf(f, "%s unable to parse channel parameter", config.c_str()); });
-    exit(-1);
-  }
-  if (pirate_set_channel_param(gd, O_RDONLY, &param) < 0) {
-    channel_errlog([config](FILE* f) { fprintf(f, "%s unable to set read channel parameter", config.c_str()); });
-    exit(-1);
-  }
-  if (pirate_set_channel_param(gd, O_WRONLY, &param) < 0) {
-    channel_errlog([config](FILE* f) { fprintf(f, "%s unable to set write channel parameter", config.c_str()); });
-    exit(-1);
-  }
-  if (pirate_pipe(gd, O_RDWR) < 0) {
-    channel_errlog([config](FILE* f) { fprintf(f, "%s unable to open pirate pipe", config.c_str()); });
-    exit(-1);
-  }
-}

--- a/demos/pnt_demo/4.pirate/channel_fd.h
+++ b/demos/pnt_demo/4.pirate/channel_fd.h
@@ -16,7 +16,7 @@ void piratePipe(const std::string& config, int gd);
 template<typename T>
 Sender<T> gdSender(const std::string& config, int gd) {
   auto sendFn = [config, gd](const T& d) { gdCheckedWrite(config, gd, &d, sizeof(T)); };
-  auto closeFn = [gd]() { pirate_close(gd, O_WRONLY); };
+  auto closeFn = [gd]() { pirate_close(gd); };
   return Sender<T>(sendFn, closeFn);
 }
 
@@ -58,7 +58,7 @@ void gdDatagramReadMessages(const std::string& config, int gd, std::function<voi
     }
     f(x);
   }
-  pirate_close(gd, O_RDONLY);
+  pirate_close(gd);
 }
 
 template<typename T>

--- a/demos/pnt_demo/4.pirate/channel_fd.h
+++ b/demos/pnt_demo/4.pirate/channel_fd.h
@@ -21,18 +21,11 @@ Sender<T> gdSender(const std::string& config, int gd) {
 }
 
 template<typename T>
-Sender<T> pirateSender(const std::string& config, int gd) {
-    pirate_channel_param_t param;
+Sender<T> pirateSender(const std::string& config) {
+    int gd;
 
-    if (pirate_parse_channel_param(config.c_str(), &param) < 0) {
-        channel_errlog([config](FILE* f) { fprintf(f, "%s unable to set channel parameter", config.c_str()); });
-        exit(-1);
-    }
-    if (pirate_set_channel_param(gd, O_WRONLY, &param) < 0) {
-        channel_errlog([config](FILE* f) { fprintf(f, "%s unable to set channel parameter", config.c_str()); });
-        exit(-1);
-    }
-    if (pirate_open(gd, O_WRONLY) < 0) {
+    gd = pirate_open_parse(config.c_str(), O_WRONLY);
+    if (gd < 0) {
         channel_errlog([config](FILE* f) { fprintf(f, "Open %s failed (error = %d)", config.c_str(), errno); });
         exit(-1);
     }
@@ -76,18 +69,11 @@ Receiver<T> gdReceiver(const std::string& config, int gd) {
 }
 
 template<typename T>
-Receiver<T> pirateReceiver(const std::string& config, int gd) {
-    pirate_channel_param_t param;
+Receiver<T> pirateReceiver(const std::string& config) {
+    int gd;
 
-    if (pirate_parse_channel_param(config.c_str(), &param) < 0) {
-        channel_errlog([config](FILE* f) { fprintf(f, "%s unable to set channel parameter", config.c_str()); });
-        exit(-1);
-    }
-    if (pirate_set_channel_param(gd, O_RDONLY, &param) < 0) {
-        channel_errlog([config](FILE* f) { fprintf(f, "%s unable to set channel parameter", config.c_str()); });
-        exit(-1);
-    }
-    if (pirate_open(gd, O_RDONLY) < 0) {
+    gd = pirate_open_parse(config.c_str(), O_RDONLY);
+    if (gd < 0) {
         channel_errlog([config](FILE* f) { fprintf(f, "Open %s failed (error = %d)", config.c_str(), errno); });
         exit(-1);
     }

--- a/demos/pnt_demo/4.pirate/pnt_example.cpp
+++ b/demos/pnt_demo/4.pirate/pnt_example.cpp
@@ -71,9 +71,9 @@ int run_green(int argc, char** argv) PIRATE_ENCLAVE_MAIN("green")
 //  piratePipe(gpsToTarget, 0);
 //  auto gpsToTargetSend = gdSender<Position>(gpsToTarget, 0);            // Green to green
 //  auto gpsToTargetRecv = gdReceiver<Position>(gpsToTarget, 0);          // Green to green
-  auto gpsToUAVSend    = pirateSender<Position>(gpsToUAVPath, 0);       // Green to orange
-  auto uavToTargetRecv = pirateReceiver<Position>(uavToTargetPath, 1);  // Orange to green
-  auto rfToTargetRecv  = pirateReceiver<Distance>(rfToTargetPath, 2);   // Orange to green
+  auto gpsToUAVSend    = pirateSender<Position>(gpsToUAVPath);       // Green to orange
+  auto uavToTargetRecv = pirateReceiver<Position>(uavToTargetPath);  // Orange to green
+  auto rfToTargetRecv  = pirateReceiver<Distance>(rfToTargetPath);   // Orange to green
 
   // Function to call when gps changes to update target.
   std::function<void(Position)> onGPSChange;
@@ -160,9 +160,9 @@ int run_orange(int argc, char** argv) PIRATE_ENCLAVE_MAIN("orange")
   }
 
   // Create channels (Note: Order must match corresponding run_green channel creation order)
-  auto gpsToUAVRecv    = pirateReceiver<Position>(gpsToUAVPath, 1);    // Green to orange
-  auto uavToTargetSend = pirateSender<Position>(uavToTargetPath, 2);  // Orange to green
-  auto rfToTargetSend  = pirateSender<Distance>(rfToTargetPath, 3);   // Orange to green
+  auto gpsToUAVRecv    = pirateReceiver<Position>(gpsToUAVPath);    // Green to orange
+  auto uavToTargetSend = pirateSender<Position>(uavToTargetPath);  // Orange to green
+  auto rfToTargetSend  = pirateSender<Distance>(rfToTargetPath);   // Orange to green
 
   Time start;
 

--- a/demos/simple_demo/src/demo.c
+++ b/demos/simple_demo/src/demo.c
@@ -453,11 +453,11 @@ int main_high(int argc, char* argv[]) GAPS_MAIN("high")
         retval = -1;
     }
 
-    if (pirate_close(high_to_low, O_WRONLY) < 0) {
+    if (pirate_close(high_to_low) < 0) {
         perror("close high to low channel in write-only mode");
         retval = -1;
     }
-    if (pirate_close(low_to_high, O_RDONLY) < 0) {
+    if (pirate_close(low_to_high) < 0) {
         perror("close low to high channel in read-only mode");
         retval = -1;
     }
@@ -544,11 +544,11 @@ int main_low(int argc, char* argv[]) GAPS_MAIN("low")
         retval = -1;
     }
 
-    if (pirate_close(high_to_low, O_RDONLY) < 0) {
+    if (pirate_close(high_to_low) < 0) {
         perror("close high to low channel in read-only mode");
         retval = -1;
     }
-    if (pirate_close(low_to_high, O_WRONLY) < 0) {
+    if (pirate_close(low_to_high) < 0) {
         perror("close low to high channel in write-only mode");
         retval = -1;
     }

--- a/demos/simple_demo/src/demo.c
+++ b/demos/simple_demo/src/demo.c
@@ -39,8 +39,7 @@
 #define GAPS_MAIN(name) __attribute__((pirate_enclave_main(name)))
 #endif
 
-#define HIGH_TO_LOW_CH 0
-#define LOW_TO_HIGH_CH 1
+int high_to_low, low_to_high;
 
 #define DATA_LEN            (32 << 10)         // 32 KB
 typedef struct {
@@ -114,13 +113,13 @@ static int load_web_content_low(data_t* data, char *path) {
     ssize_t num;
 
     len = strnlen(path, PATHSIZE);
-    num = pirate_write(LOW_TO_HIGH_CH, &len, sizeof(int));
+    num = pirate_write(low_to_high, &len, sizeof(int));
     if (num != sizeof(int)) {
         fprintf(stderr, "Failed to send request length\n");
         return 500;
     }
 
-    num = pirate_write(LOW_TO_HIGH_CH, path, len);
+    num = pirate_write(low_to_high, path, len);
     if (num != len) {
         fprintf(stderr, "Failed to send request path\n");
         return 500;
@@ -128,7 +127,7 @@ static int load_web_content_low(data_t* data, char *path) {
 
     fputs("Sent read request to the HIGH_NAME side\n", stdout);
 
-    num = pirate_read(HIGH_TO_LOW_CH, &rv, sizeof(rv));
+    num = pirate_read(high_to_low, &rv, sizeof(rv));
     if (num != sizeof(rv)) {
         fprintf(stderr, "Failed to receive status code\n");
         return 500;
@@ -138,7 +137,7 @@ static int load_web_content_low(data_t* data, char *path) {
     }
 
     /* Read and validate response length */
-    num = pirate_read(HIGH_TO_LOW_CH, &len, sizeof(len));
+    num = pirate_read(high_to_low, &len, sizeof(len));
     if (num != sizeof(len)) {
         fprintf(stderr, "Failed to receive response length\n");
         return 500;
@@ -150,7 +149,7 @@ static int load_web_content_low(data_t* data, char *path) {
     }
 
     /* Read back the response */
-    num = pirate_read(HIGH_TO_LOW_CH, data->buf, len);
+    num = pirate_read(high_to_low, data->buf, len);
     if (num != len) {
         fprintf(stderr, "Failed to read back the response\n");
         return 500;
@@ -192,7 +191,7 @@ static void* gaps_thread(void *arg) {
         int rv, len = 0;
         char path[PATHSIZE];
 
-        ssize_t num = pirate_read(LOW_TO_HIGH_CH, &len, sizeof(len));
+        ssize_t num = pirate_read(low_to_high, &len, sizeof(len));
         if (num != sizeof(len)) {
             if (!terminated) {
                 fprintf(stderr, "Failed to read request from the low side\n");
@@ -208,7 +207,7 @@ static void* gaps_thread(void *arg) {
         }
 
         memset(path, 0, sizeof(path));
-        num = pirate_read(LOW_TO_HIGH_CH, &path, len);
+        num = pirate_read(low_to_high, &path, len);
         if (num != len) {
             fprintf(stderr, "Invalid request path from the low side %d\n", len);
             terminate();
@@ -219,7 +218,7 @@ static void* gaps_thread(void *arg) {
 
         /* Read in high data */
         rv = load_web_content_high(&data, path);
-        num = pirate_write(HIGH_TO_LOW_CH, &rv, sizeof(rv));
+        num = pirate_write(high_to_low, &rv, sizeof(rv));
         if (num != sizeof(rv)) {
             fprintf(stderr, "Failed to send status code\n");
             terminate();
@@ -247,14 +246,14 @@ static void* gaps_thread(void *arg) {
         }
 
         /* Reply back. Data length is sent first */
-        num = pirate_write(HIGH_TO_LOW_CH, &data.len, sizeof(data.len));
+        num = pirate_write(high_to_low, &data.len, sizeof(data.len));
         if (num != sizeof(data.len)) {
             fprintf(stderr, "Failed to send response length\n");
             terminate();
             continue;
         }
 
-        num = pirate_write(HIGH_TO_LOW_CH, &data.buf, data.len);
+        num = pirate_write(high_to_low, &data.buf, data.len);
         if (num != data.len) {
             fprintf(stderr, "Failed to send response content\n");
             terminate();
@@ -406,22 +405,14 @@ int main_high(int argc, char* argv[]) GAPS_MAIN("high")
 
     pirate_init_channel_param(PIPE, &param);
 
-    if (pirate_set_channel_param(HIGH_TO_LOW_CH, O_WRONLY, &param) < 0) {
-        perror("channel parameter set: high->low");
-        return -1;
-    }
-
-    if (pirate_set_channel_param(LOW_TO_HIGH_CH, O_RDONLY, &param) < 0) {
-        perror("channel parameter set: high<-low");
-        return -1;
-    }
-
-    if (pirate_open(HIGH_TO_LOW_CH, O_WRONLY) < 0) {
+    high_to_low = pirate_open_param(&param, O_WRONLY);
+    if (high_to_low < 0) {
         perror("open high to low channel in write-only mode");
         return -1;
     }
 
-    if (pirate_open(LOW_TO_HIGH_CH, O_RDONLY) < 0) {
+    low_to_high = pirate_open_param(&param, O_RDONLY);
+    if (low_to_high < 0) {
         perror("open low to high channel in read-only mode");
         return -1;
     }
@@ -462,11 +453,11 @@ int main_high(int argc, char* argv[]) GAPS_MAIN("high")
         retval = -1;
     }
 
-    if (pirate_close(HIGH_TO_LOW_CH, O_WRONLY) < 0) {
+    if (pirate_close(high_to_low, O_WRONLY) < 0) {
         perror("close high to low channel in write-only mode");
         retval = -1;
     }
-    if (pirate_close(LOW_TO_HIGH_CH, O_RDONLY) < 0) {
+    if (pirate_close(low_to_high, O_RDONLY) < 0) {
         perror("close low to high channel in read-only mode");
         retval = -1;
     }
@@ -520,21 +511,13 @@ int main_low(int argc, char* argv[]) GAPS_MAIN("low")
 
     pirate_init_channel_param(PIPE, &param);
 
-    if (pirate_set_channel_param(HIGH_TO_LOW_CH, O_RDONLY, &param) < 0) {
-        perror("channel parameter set: high->low");
-        return -1;
-    }
-
-    if (pirate_set_channel_param(LOW_TO_HIGH_CH, O_WRONLY, &param) < 0) {
-        perror("channel parameter set: high<-low");
-        return -1;
-    }
-
-    if (pirate_open(HIGH_TO_LOW_CH, O_RDONLY) < 0) {
+    high_to_low = pirate_open_param(&param, O_RDONLY);
+    if (high_to_low < 0) {
         perror("open high to low channel in read-only mode");
         return -1;
     }
-    if (pirate_open(LOW_TO_HIGH_CH, O_WRONLY) < 0) {
+    low_to_high = pirate_open_param(&param, O_WRONLY);
+    if (low_to_high < 0) {
         perror("open low to high channel in write-only mode");
         return -1;
     }
@@ -561,11 +544,11 @@ int main_low(int argc, char* argv[]) GAPS_MAIN("low")
         retval = -1;
     }
 
-    if (pirate_close(HIGH_TO_LOW_CH, O_RDONLY) < 0) {
+    if (pirate_close(high_to_low, O_RDONLY) < 0) {
         perror("close high to low channel in read-only mode");
         retval = -1;
     }
-    if (pirate_close(LOW_TO_HIGH_CH, O_WRONLY) < 0) {
+    if (pirate_close(low_to_high, O_WRONLY) < 0) {
         perror("close low to high channel in write-only mode");
         retval = -1;
     }

--- a/demos/time_demo/src/common.c
+++ b/demos/time_demo/src/common.c
@@ -138,7 +138,7 @@ int gaps_app_wait_exit(gaps_app_t *ctx) {
             break;
         }
 
-        pirate_close(c->num, c->flags);
+        pirate_close(c->num);
     }
 
     // Stop worker threads

--- a/demos/time_demo/src/common.c
+++ b/demos/time_demo/src/common.c
@@ -90,13 +90,8 @@ int gaps_app_run(gaps_app_t *ctx) {
             return rv;
         }
 
-        rv = pirate_set_channel_param(c->num, c->flags, &param);
-        if (rv != 0) {
-            ts_log(ERROR, "Failed to set channel parameters for %s", c->desc);
-            return -1;
-        }
-
-        if (pirate_open(c->num, c->flags) != c->num) {
+        c->num = pirate_open_param(&param, c->flags);
+        if (c->num < 0) {
             ts_log(ERROR, "Failed to open channel %s", c->desc);
             return -1;
         }

--- a/libpirate/README.md
+++ b/libpirate/README.md
@@ -2,8 +2,8 @@
 
 Pirate primitives layer. The PIRATE core primitives layer
 will provide a series of capabilities for executing PIRATE executables
-on TA1 hardware. At minimum, there are four basic primitives that must
-be supported: configuring TA1 hardware, loading code and data onto the
+on GAPS hardware. At minimum, there are four basic primitives that must
+be supported: configuring GAPS hardware, loading code and data onto the
 appropriate CPU, implementing channel send and receive calls, and resource
 cleanup / data wipe on termination.
 
@@ -14,65 +14,57 @@ See [libpirate.h](/libpirate/libpirate.h) for additional documentation.
 Reader:
 
 ```
-  pirate_channel_param_t param
-  pirate_init_channel_param(PIPE, &param);
-
-  int data;
-  if (pirate_open(1, O_RDONLY) < 0) {
+  int gd, data;
+  gd = pirate_open_parse("pipe,/tmp/gaps", O_RDONLY);
+  if (gd < 0) {
     perror("reader open error");
     exit(1);
   }
-  if (pirate_read(1, &data, sizeof(data)) != sizeof(data)) {
+  if (pirate_read(gd, &data, sizeof(data)) != sizeof(data)) {
     perror("read error");
     exit(2);
   }
-  pirate_close(1);
+  pirate_close(gd);
 ```
 
 Writer:
 
 ```
-  pirate_channel_param_t param
-  pirate_init_channel_param(PIPE, &param);
-
-  int data = 1234;
-  if (pirate_open(1, O_WRONLY) < 0) {
+  int gd, data = 1234;
+  gd = pirate_open_parse("pipe,/tmp/gaps", O_WRONLY);
+  if (gd < 0) {
     perror("writer open error");
     exit(1);
   }
-  if (pirate_write(1, &data, sizeof(data)) != sizeof(data)) {
+  if (pirate_write(gd, &data, sizeof(data)) != sizeof(data)) {
     perror("write error");
     exit(2);
   }
-  pirate_close(1);
+  pirate_close(gd);
 ```
 
 ## Channel types
 
 ### PIPE type
 
-Linux named pipes are the default channel type. A pipe file is
-created at `/tmp/gaps.channel.%d` if one does not exist.
+Linux named pipes. Path to named pipe must be specified.
 
 ### DEVICE type
 
-The pathname to the character device must be specified using
-`pirate_set_pathname(int, char *)` prior to opening the channel.
+The pathname to the character device must be specified
+prior to opening the channel.
 
 ### UNIX_SOCKET type
 
-Unix domain socket communication. A unix socket file is
-created at `/tmp/gaps.channel.%d.sock` if one does not exist.
+Unix domain socket communication. Path to Unix socket must be specified.
 
 ### TCP_SOCKET type
 
-TCP socket communication. The port number is (26427 + d)
-where d is the gaps descriptor.
+TCP socket communication. Host and port must be specified.
 
 ### UDP_SOCKET type
 
-UDP socket communication. The port number is (26427 + d)
-where d is the gaps descriptor.
+UDP socket communication. Host and port must be specified.
 
 ### SHMEM type
 
@@ -81,10 +73,6 @@ for the SHMEM type requires the librt.so POSIX real-time extensions
 library. This support is not included by default. Set
 the PIRATE_SHMEM_FEATURE flag in [CMakeLists.txt](/libpirate/CMakeLists.txt)
 to enable support for shared memory.
-
-If the reader or writer process is killed while blocked
-on pirate_open() then you must delete the file
-`/dev/shm/gaps.channel.%d` prior to launching another reader or writer.
 
 The SHMEM type is intended for benchmarking purposes only.
 The size of the shared memory buffer can be specified using

--- a/libpirate/README.md
+++ b/libpirate/README.md
@@ -26,7 +26,7 @@ Reader:
     perror("read error");
     exit(2);
   }
-  pirate_close(1, RD_ONLY);
+  pirate_close(1);
 ```
 
 Writer:
@@ -44,7 +44,7 @@ Writer:
     perror("write error");
     exit(2);
   }
-  pirate_close(1, O_WRONLY);
+  pirate_close(1);
 ```
 
 ## Channel types

--- a/libpirate/bench/primitives_bench_lat.c
+++ b/libpirate/bench/primitives_bench_lat.c
@@ -218,8 +218,8 @@ int main(int argc, char *argv[]) {
         nbytes -= rv;
       }
     }
-    pirate_close(1, O_RDONLY);
-    pirate_close(2, O_WRONLY);
+    pirate_close(1);
+    pirate_close(2);
   } else {
     // parent
     if (set_buffer_size(1, bufsize) < 0) {
@@ -328,8 +328,8 @@ int main(int argc, char *argv[]) {
       perror("clock_gettime");
       return 1;
     }
-    pirate_close(1, O_WRONLY);
-    pirate_close(2, O_RDONLY);
+    pirate_close(1);
+    pirate_close(2);
     // nanoseconds difference
     delta = ((stop.tv_sec - start.tv_sec) * 1000000000 +
              (stop.tv_nsec - start.tv_nsec));

--- a/libpirate/bench/primitives_bench_lat_percentiles.c
+++ b/libpirate/bench/primitives_bench_lat_percentiles.c
@@ -216,8 +216,8 @@ int main(int argc, char *argv[]) {
         }
       }
     }
-    pirate_close(1, O_RDONLY);
-    pirate_close(2, O_WRONLY);
+    pirate_close(1);
+    pirate_close(2);
   } else {
     // parent
     if (set_buffer_size(1, bufsize) < 0) {
@@ -324,8 +324,8 @@ int main(int argc, char *argv[]) {
       datapoints[i] = delta / (ITERATIONS * 2);
     }
     wait(NULL);
-    pirate_close(1, O_WRONLY);
-    pirate_close(2, O_RDONLY);
+    pirate_close(1);
+    pirate_close(2);
     for (i = 0; i < count; i++) {
       printf("%ld\n", datapoints[i]);
     }

--- a/libpirate/bench/primitives_bench_thr.c
+++ b/libpirate/bench/primitives_bench_thr.c
@@ -160,7 +160,7 @@ int main(int argc, char *argv[]) {
     // 1e6 bytes per megabytes
     printf("average throughput: %f MB/s\n",
            ((1e9 / 1e6) * (count / PIRATE_IOV_MAX) * (size * PIRATE_IOV_MAX)) / delta);
-    pirate_close(1, O_RDONLY);
+    pirate_close(1);
   } else {
     // parent
     if (set_buffer_size(1, bufsize) < 0) {
@@ -217,7 +217,7 @@ int main(int argc, char *argv[]) {
       }
     }
     wait(NULL);
-    pirate_close(1, O_WRONLY);
+    pirate_close(1);
   }
   free(buf);
 }

--- a/libpirate/bench/primitives_bench_thr_vector.c
+++ b/libpirate/bench/primitives_bench_thr_vector.c
@@ -154,7 +154,7 @@ int main(int argc, char *argv[]) {
     // 1e6 bytes per megabytes
     printf("average throughput: %f MB/s\n",
            ((1e9 / 1e6) * (count / PIRATE_IOV_MAX) * (size * PIRATE_IOV_MAX)) / delta);
-    pirate_close(1, O_RDONLY);
+    pirate_close(1);
   } else {
     // parent
     if (set_buffer_size(1, bufsize) < 0) {
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
       }
     }
     wait(NULL);
-    pirate_close(1, O_WRONLY);
+    pirate_close(1);
   }
   free(buf);
 }

--- a/libpirate/channel_mgmt.c
+++ b/libpirate/channel_mgmt.c
@@ -59,7 +59,7 @@ void __attribute__ ((destructor(PIRATE_DTOR_PRIO))) pirate_channel_term() {
             continue;
         }
 
-        pirate_close(ch->num, ch->flags);
+        pirate_close(ch->num);
         ch->gd = -1;
     }
 }

--- a/libpirate/device.c
+++ b/libpirate/device.c
@@ -44,17 +44,16 @@ int pirate_device_parse_param(char *str, pirate_device_param_t *param) {
     return 0;
 }
 
-int pirate_device_open(int gd, int flags, pirate_device_param_t *param, device_ctx *ctx) {
-    if (ctx->fd > 0) {
-        errno = EBUSY;
+int pirate_device_open(int flags, pirate_device_param_t *param, device_ctx *ctx) {
+    if (strnlen(param->path, 1) == 0) {
+        errno = EINVAL;
         return -1;
     }
-
     if ((ctx->fd = open(param->path, flags)) < 0) {
         return -1;
     }
     
-    return gd;
+    return 0;
 }
 
 int pirate_device_close(device_ctx *ctx) {

--- a/libpirate/device.h
+++ b/libpirate/device.h
@@ -24,7 +24,7 @@ typedef struct {
 } device_ctx;
 
 int pirate_device_parse_param(char *str, pirate_device_param_t *param);
-int pirate_device_open(int gd, int flags, pirate_device_param_t *param, device_ctx *ctx);
+int pirate_device_open(int flags, pirate_device_param_t *param, device_ctx *ctx);
 int pirate_device_close(device_ctx *ctx);
 ssize_t pirate_device_read(const pirate_device_param_t *param, device_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_device_write(const pirate_device_param_t *param, device_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -117,12 +117,9 @@ static int ge_message_unpack(const void *buf, void *data, uint32_t mtu,
     return 0;
 }
 
-static void pirate_ge_eth_init_param(int gd, pirate_ge_eth_param_t *param) {
+static void pirate_ge_eth_init_param(pirate_ge_eth_param_t *param) {
     if (strnlen(param->addr, 1) == 0) {
         snprintf(param->addr, sizeof(param->addr) - 1, DEFAULT_GE_ETH_IP_ADDR);
-    }
-    if (param->port == 0) {
-        param->port = DEFAULT_GE_ETH_IP_PORT + gd;
     }
     if (param->mtu == 0) {
         param->mtu = DEFAULT_GE_ETH_MTU;
@@ -137,13 +134,17 @@ int pirate_ge_eth_parse_param(char *str, pirate_ge_eth_param_t *param) {
         return -1;
     }
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        strncpy(param->addr, ptr, sizeof(param->addr));
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    strncpy(param->addr, ptr, sizeof(param->addr));
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        param->port = strtol(ptr, NULL, 10);
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    param->port = strtol(ptr, NULL, 10);
 
     if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
         param->mtu = strtol(ptr, NULL, 10);
@@ -213,10 +214,14 @@ static int ge_eth_writer_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     return 0;
 }
 
-int pirate_ge_eth_open(int gd, int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
+int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     int rv = -1;
 
-    pirate_ge_eth_init_param(gd, param);
+    pirate_ge_eth_init_param(param);
+    if (param->port <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
     ctx->buf = (uint8_t *) malloc(param->mtu);
     if (ctx->buf == NULL) {
         return -1;
@@ -228,7 +233,7 @@ int pirate_ge_eth_open(int gd, int flags, pirate_ge_eth_param_t *param, ge_eth_c
         rv = ge_eth_writer_open(param, ctx);
     }
 
-    return rv == 0 ? gd : rv;
+    return rv;
 }
 
 int pirate_ge_eth_close(ge_eth_ctx *ctx) {

--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -216,6 +216,7 @@ static int ge_eth_writer_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
 
 int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
 
     pirate_ge_eth_init_param(param);
     if (param->port <= 0) {
@@ -227,9 +228,9 @@ int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx)
         return -1;
     }
 
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = ge_eth_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else if (access == O_WRONLY) {
         rv = ge_eth_writer_open(param, ctx);
     }
 

--- a/libpirate/ge_eth.h
+++ b/libpirate/ge_eth.h
@@ -24,7 +24,7 @@ typedef struct {
 } ge_eth_ctx;
 
 int pirate_ge_eth_parse_param(char *str, pirate_ge_eth_param_t *param);
-int pirate_ge_eth_open(int gd, int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx);
+int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx);
 int pirate_ge_eth_close(ge_eth_ctx *ctx);
 ssize_t pirate_ge_eth_read(const pirate_ge_eth_param_t *param, ge_eth_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_ge_eth_write(const pirate_ge_eth_param_t *param, ge_eth_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -318,11 +318,19 @@ int pirate_open_param(pirate_channel_param_t *param, int flags);
 // The caller is responsible for closing the reader and the writer.
 //
 // On success, zero is returned. On error, -1 is returned,
-// and errno is set appropriately.
+// and errno is set appropriately. If the channel type
+// does not support this functionality then errno is set
+// to ENOSYS.
 //
 // The argument flags must be O_RDWR.
 
 int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
+
+// Returns 1 if the channel type supports the
+// pirate_pipe_param() and pirate_pipe_parse()
+// functions. Otherwise return 0.
+
+int pirate_pipe_channel_type(channel_enum_t channel_type);
 
 // pirate_read() attempts to read up to count bytes from
 // gaps descriptor gd into the buffer starting at buf.

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -295,7 +295,7 @@ int pirate_get_channel_param(int gd, pirate_channel_param_t *param);
 // The return value is the input gaps descriptor, or -1 if an
 // error occurred (in which case, errno is set appropriately).
 //
-// The argument flags must be O_RDONLY or O_WRONLY.
+// The argument flags must have access mode O_RDONLY or O_WRONLY.
 
 int pirate_open_parse(const char *param, int flags);
 
@@ -307,7 +307,7 @@ int pirate_open_parse(const char *param, int flags);
 // The return value is a unique gaps descriptor, or -1 if an
 // error occurred (in which case, errno is set appropriately).
 //
-// The argument flags must be O_RDONLY or O_WRONLY.
+// The argument flags must have access mode O_RDONLY or O_WRONLY.
 
 int pirate_open_param(pirate_channel_param_t *param, int flags);
 
@@ -328,7 +328,7 @@ int pirate_pipe_channel_type(channel_enum_t channel_type);
 // does not support this functionality then errno is set
 // to ENOSYS.
 //
-// The argument flags must be O_RDWR.
+// The argument flags must have access mode O_RDWR.
 
 int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 
@@ -343,7 +343,7 @@ int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 // does not support this functionality then errno is set
 // to ENOSYS.
 //
-// The argument flags must be O_RDWR.
+// The argument flags must have access mode O_RDWR.
 
 int pirate_pipe_parse(int gd[2], const char *param, int flags);
 

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -311,8 +311,14 @@ int pirate_open_parse(const char *param, int flags);
 
 int pirate_open_param(pirate_channel_param_t *param, int flags);
 
+// Returns 1 if the channel type supports the
+// pirate_pipe_param() and pirate_pipe_parse()
+// functions. Otherwise return 0.
+
+int pirate_pipe_channel_type(channel_enum_t channel_type);
+
 // Opens both ends of the gaps channel specified by the
-// gaps descriptor. See pipe() system call. Some channel
+// parameter value. See pipe() system call. Some channel
 // types cannot be opened for both reading and writing.
 //
 // The caller is responsible for closing the reader and the writer.
@@ -326,11 +332,20 @@ int pirate_open_param(pirate_channel_param_t *param, int flags);
 
 int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 
-// Returns 1 if the channel type supports the
-// pirate_pipe_param() and pirate_pipe_parse()
-// functions. Otherwise return 0.
+// Opens both ends of the gaps channel specified by the
+// parameter string. See pipe() system call. Some channel
+// types cannot be opened for both reading and writing.
+//
+// The caller is responsible for closing the reader and the writer.
+//
+// On success, zero is returned. On error, -1 is returned,
+// and errno is set appropriately. If the channel type
+// does not support this functionality then errno is set
+// to ENOSYS.
+//
+// The argument flags must be O_RDWR.
 
-int pirate_pipe_channel_type(channel_enum_t channel_type);
+int pirate_pipe_parse(int gd[2], const char *param, int flags);
 
 // pirate_read() attempts to read up to count bytes from
 // gaps descriptor gd into the buffer starting at buf.

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 #define PIRATE_LEN_NAME 64
-#define PIRATE_NUM_CHANNELS 16
+#define PIRATE_NUM_CHANNELS 64
 #define PIRATE_IOV_MAX 16
 
 typedef enum {
@@ -46,13 +46,12 @@ typedef enum {
     // The gaps channel is implemented using a FIFO special file
     // (a named pipe).
     // Configuration parameters - pirate_pipe_param_t
-    //  - path    - if "" then PIRATE_FILENAME format is used instead
+    //  - path    - file path to named pipe
     //  - iov_len - I/O vector chunk length
     PIPE,
 
-    // The name of the socket is formatted with PIRATE_DOMAIN_FILENAME
-    // where %d is the gaps descriptor.
-    //  - path        - if "" then PIRATE_FILENAME format is used instead
+    // The gaps channel is implemented using a Unix domain socket.
+    //  - path        - file path to unix socket
     //  - iov_len     - I/O vector chunk length
     //  - buffer_size - unix socket buffer size
     UNIX_SOCKET,
@@ -60,7 +59,7 @@ typedef enum {
     // The gaps channel is implemented by using TCP sockets.
     // Configuration parameters - pirate_tcp_socket_param_t
     //  - addr        - IP address, if empty then 127.0.0.1 is used
-    //  - port        - IP port, if empty, then 26427 + aps descriptor is used
+    //  - port        - IP port
     //  - iov_len     - I/O vector chunk length
     //  - buffer_size - TCP socket buffer size
     TCP_SOCKET,
@@ -68,7 +67,7 @@ typedef enum {
     // The gaps channel is implemented by using TCP sockets.
     // Configuration parameters - pirate_tcp_socket_param_t
     //  - addr        - IP address, if empty then 127.0.0.1 is used
-    //  - port        - IP port, if empty, then 26427 + aps descriptor is used
+    //  - port        - IP port
     //  - iov_len     - I/O vector chunk length
     //  - buffer_size - UDP socket buffer size
     UDP_SOCKET,
@@ -119,7 +118,7 @@ typedef enum {
     // The gaps channel for GRC Ethernet devices
     // Configuration parameters - pirate_ge_eth_param_t
     //  - addr - IP address, if empty then 127.0.0.1 is used
-    //  - port - IP port, if empty, then 0x4745 + aps descriptor is used
+    //  - port - IP port
     //  - mtu  - maximum frame length, default 1454
     GE_ETH
 } channel_enum_t;
@@ -131,14 +130,12 @@ typedef struct {
 } pirate_device_param_t;
 
 // PIPE parameters
-#define PIRATE_PIPE_NAME_FMT                "/tmp/gaps.channel.%d"
 typedef struct {
     char path[PIRATE_LEN_NAME];
     unsigned iov_len;
 } pirate_pipe_param_t;
 
 // UNIX_SOCKET parameters
-#define PIRATE_UNIX_SOCKET_NAME_FMT         "/tmp/gaps.channel.%d.sock"
 typedef struct {
     char path[PIRATE_LEN_NAME];
     unsigned iov_len;
@@ -147,7 +144,6 @@ typedef struct {
 
 // TCP_SOCKET parameters
 #define DEFAULT_TCP_IP_ADDR                 "127.0.0.1"
-#define PIRATE_TCP_PORT_BASE                26427
 typedef struct {
     char addr[INET_ADDRSTRLEN];
     short port;
@@ -157,7 +153,6 @@ typedef struct {
 
 // UDP_SOCKET parameters
 #define DEFAULT_UDP_IP_ADDR                 "127.0.0.1"
-#define PIRATE_UDP_PORT_BASE                26427
 typedef struct {
     char addr[INET_ADDRSTRLEN];
     short port;
@@ -167,7 +162,6 @@ typedef struct {
 
 // SHMEM parameters
 #define DEFAULT_SMEM_BUF_LEN                (128u << 10)
-#define PIRATE_SHMEM_NAME_FMT               "/gaps.channel.%d"
 typedef struct {
     char path[PIRATE_LEN_NAME];
     unsigned buffer_size;
@@ -187,10 +181,10 @@ typedef struct {
 #define DEFAULT_UIO_DEVICE  "/dev/uio0"
 typedef struct {
     char path[PIRATE_LEN_NAME];
+    unsigned short region;
 } pirate_uio_param_t;
 
 // SERIAL parameters
-#define PIRATE_SERIAL_NAME_FMT  "/dev/ttyUSB%d"
 #define SERIAL_DEFAULT_BAUD     B230400
 #define SERIAL_DEFAULT_MTU      1024u
 typedef struct {
@@ -220,7 +214,6 @@ typedef struct {
 
 // GE_ETH parameters
 #define DEFAULT_GE_ETH_IP_ADDR  "127.0.0.1"
-#define DEFAULT_GE_ETH_IP_PORT  0x4745
 #define DEFAULT_GE_ETH_MTU      1454u
 typedef struct {
     char addr[INET_ADDRSTRLEN];
@@ -271,28 +264,16 @@ int pirate_parse_channel_param(const char *str, pirate_channel_param_t *param);
 #define GAPS_CHANNEL_OPTIONS                                                   \
     "Supported channels:\n"                                                    \
     "  DEVICE        device,path[,iov_len]\n"                                  \
-    "  PIPE          pipe[,path,iov_len]\n"                                    \
-    "  UNIX SOCKET   unix_socket[,path,iov_len,buffer_size]\n"                 \
-    "  TCP SOCKET    tcp_socket[,addr,port,iov_len,buffer_size]\n"             \
-    "  UDP SOCKET    udp_socket[,addr,port,iov_len,buffer_size]\n"             \
-    "  SHMEM         shmem[,path,buffer_size]\n"                               \
-    "  UDP_SHMEM     udp_shmem[,path,buffer_size,packet_size,packet_count]\n"  \
+    "  PIPE          pipe,path[,iov_len]\n"                                    \
+    "  UNIX SOCKET   unix_socket,path[,iov_len,buffer_size]\n"                 \
+    "  TCP SOCKET    tcp_socket,addr,port[,iov_len,buffer_size]\n"             \
+    "  UDP SOCKET    udp_socket,addr,port[,iov_len,buffer_size]\n"             \
+    "  SHMEM         shmem,path[,buffer_size]\n"                               \
+    "  UDP_SHMEM     udp_shmem,path[,buffer_size,packet_size,packet_count]\n"  \
     "  UIO           uio[,path]\n"                                             \
-    "  SERIAL        serial[,path,baud,mtu]\n"                                 \
+    "  SERIAL        serial,path[,baud,mtu]\n"                                 \
     "  MERCURY       mercury,level,src_id,dst_id[,timeout_ms,msg_id_1,...]\n"  \
-    "  GE_ETH        ge_eth[,addr,port,mtu]\n"
-
-// Copies channel parameters from param argument into configuration.
-//
-// Parameters:
-//  gd           - GAPS channel number
-//  flags        - O_RDONLY or O_WRONLY
-//  param        - channel-specific parameters.
-// Return:
-//  0 on success
-// -1 on failure, errno is set
-
-int pirate_set_channel_param(int gd, int flags, const pirate_channel_param_t *param);
+    "  GE_ETH        ge_eth,addr,port[,mtu]\n"
 
 // Copies channel parameters from configuration into param argument.
 //
@@ -307,33 +288,42 @@ int pirate_set_channel_param(int gd, int flags, const pirate_channel_param_t *pa
 
 int pirate_get_channel_param(int gd, int flags, pirate_channel_param_t *param);
 
-// Opens the gaps channel specified by the gaps descriptor.
+// Opens the gaps channel specified by parameter string.
 //
-// Channels must be opened in order from smaller to largest
-// gaps descriptor. pirate_open() will block until both the
-// reader and the writer have opened the channel.
+// Channels must be opened in the same order across all
+// processes.
 
 // The return value is the input gaps descriptor, or -1 if an
 // error occurred (in which case, errno is set appropriately).
 //
 // The argument flags must be O_RDONLY or O_WRONLY.
 
-int pirate_open(int gd, int flags);
+int pirate_open_parse(const char *param, int flags);
+
+// Opens the gaps channel specified by the parameter value.
+//
+// Channels must be opened in the same order across all
+// processes.
+
+// The return value is a unique gaps descriptor, or -1 if an
+// error occurred (in which case, errno is set appropriately).
+//
+// The argument flags must be O_RDONLY or O_WRONLY.
+
+int pirate_open_param(pirate_channel_param_t *param, int flags);
 
 // Opens both ends of the gaps channel specified by the
-// gaps descriptor. Some channel types cannot be opened
-// for both reading and writing.
+// gaps descriptor. See pipe() system call. Some channel
+// types cannot be opened for both reading and writing.
 //
-// The caller is responsible for setting channel params on
-// both the reader and the writer. The caller is responsible
-// for closing the reader and the writer.
+// The caller is responsible for closing the reader and the writer.
 //
-// The return value is the input gaps descriptor, or -1 if an
+// The return value is a unique gaps descriptor, or -1 if an
 // error occurred (in which case, errno is set appropriately).
 //
 // The argument flags must be O_RDWR.
 
-int pirate_pipe(int gd, int flags);
+int pirate_pipe_param(pirate_channel_param_t *param, int flags);
 
 // pirate_read() attempts to read up to count bytes from
 // gaps descriptor gd into the buffer starting at buf.

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -10,7 +10,7 @@
  * computer software, or portions thereof marked with this legend must also
  * reproduce this marking.
  *
- * Copyright 2019 Two Six Labs, LLC.  All rights reserved.
+ * Copyright 2019-2020 Two Six Labs, LLC.  All rights reserved.
  */
 
 #ifndef __PIRATE_PRIMITIVES_H
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 #define PIRATE_LEN_NAME 64
-#define PIRATE_NUM_CHANNELS 64
+#define PIRATE_NUM_CHANNELS 16
 #define PIRATE_IOV_MAX 16
 
 typedef enum {
@@ -279,14 +279,13 @@ int pirate_parse_channel_param(const char *str, pirate_channel_param_t *param);
 //
 // Parameters
 //  gd           - GAPS channel number
-//  flags        - O_RDONLY or O_WRONLY
 //  param        - channel-specific parameters
 //
 // Return:
 //  0 on success
 // -1 on failure, errno is set
 
-int pirate_get_channel_param(int gd, int flags, pirate_channel_param_t *param);
+int pirate_get_channel_param(int gd, pirate_channel_param_t *param);
 
 // Opens the gaps channel specified by parameter string.
 //
@@ -318,12 +317,12 @@ int pirate_open_param(pirate_channel_param_t *param, int flags);
 //
 // The caller is responsible for closing the reader and the writer.
 //
-// The return value is a unique gaps descriptor, or -1 if an
-// error occurred (in which case, errno is set appropriately).
+// On success, zero is returned. On error, -1 is returned,
+// and errno is set appropriately.
 //
 // The argument flags must be O_RDWR.
 
-int pirate_pipe_param(pirate_channel_param_t *param, int flags);
+int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 
 // pirate_read() attempts to read up to count bytes from
 // gaps descriptor gd into the buffer starting at buf.
@@ -344,7 +343,7 @@ ssize_t pirate_write(int gd, const void *buf, size_t count);
 //
 // pirate_close() returns zero on success.  On error,
 // -1 is returned, and errno is set appropriately.
-int pirate_close(int gd, int flags);
+int pirate_close(int gd);
 
 #ifdef __cplusplus
 }

--- a/libpirate/libpirate_internal.h
+++ b/libpirate/libpirate_internal.h
@@ -1,0 +1,29 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
+ */
+
+#ifndef __PIRATE_INTERNAL_PRIMITIVES_H
+#define __PIRATE_INTERNAL_PRIMITIVES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void pirate_reset_gd();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //__PIRATE_INTERNAL_PRIMITIVES_H

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -292,7 +292,8 @@ int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *c
     ssize_t sz;
     int fd_root = -1;
     ctx->flags = flags;
-    const mode_t mode = ctx->flags == O_RDONLY ? S_IRUSR : S_IWUSR;
+    int access = ctx->flags & O_ACCMODE;
+    const mode_t mode = access == O_RDONLY ? S_IRUSR : S_IWUSR;
 
     /* Open the root device to configure and establish a session */
     pirate_mercury_init_param(param);
@@ -359,10 +360,10 @@ int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *c
         }
 
         snprintf(ctx->path, PIRATE_LEN_NAME - 1, PIRATE_MERCURY_DEFAULT_FMT,
-                    param->session.id, flags == O_RDONLY ? "read" : "write");
+                    param->session.id, access == O_RDONLY ? "read" : "write");
     } else {
         snprintf(ctx->path, PIRATE_LEN_NAME - 1, PIRATE_MERCURY_SESSION_FMT,
-                    param->session.id, flags == O_RDONLY ? "read" : "write");
+                    param->session.id, access == O_RDONLY ? "read" : "write");
     }
 
     /* Open the device */

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -225,11 +225,7 @@ static ssize_t mercury_message_unpack(const void *buf, ssize_t buf_len,
     return count;
 }
 
-static void pirate_mercury_init_param(int gd, pirate_mercury_param_t *param) {
-    if (param->session.level == 0) {
-        param->session.level = param->session.source_id = gd + 1;
-    }
-
+static void pirate_mercury_init_param(pirate_mercury_param_t *param) {
     if (param->mtu == 0) {
         param->mtu = PIRATE_MERCURY_DEFAULT_MTU;
     }
@@ -287,8 +283,7 @@ int pirate_mercury_parse_param(char *str, pirate_mercury_param_t *param) {
     return 0;
 }
 
-int pirate_mercury_open(int gd, int flags, pirate_mercury_param_t *param, 
-                            mercury_ctx *ctx) {
+int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *ctx) {
     const uint32_t cfg_len = sizeof(uint32_t);
     ssize_t sz;
     int fd_root = -1;
@@ -296,7 +291,7 @@ int pirate_mercury_open(int gd, int flags, pirate_mercury_param_t *param,
     const mode_t mode = ctx->flags == O_RDONLY ? S_IRUSR : S_IWUSR;
 
     /* Open the root device to configure and establish a session */
-    pirate_mercury_init_param(gd, param);
+    pirate_mercury_init_param(param);
 
     if (pthread_mutex_lock(&open_lock) != 0) {
         return -1;
@@ -377,7 +372,7 @@ int pirate_mercury_open(int gd, int flags, pirate_mercury_param_t *param,
         goto error;
     }
 
-    return gd;
+    return 0;
 error_session:
     pthread_mutex_unlock(&open_lock);
 error:

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -226,6 +226,10 @@ static ssize_t mercury_message_unpack(const void *buf, ssize_t buf_len,
 }
 
 static void pirate_mercury_init_param(pirate_mercury_param_t *param) {
+    if (param->session.source_id == 0) {
+        param->session.source_id = 1;
+    }
+
     if (param->mtu == 0) {
         param->mtu = PIRATE_MERCURY_DEFAULT_MTU;
     }

--- a/libpirate/mercury.h
+++ b/libpirate/mercury.h
@@ -26,7 +26,7 @@ typedef struct {
 } mercury_ctx;
 
 int pirate_mercury_parse_param(char *str, pirate_mercury_param_t *param);
-int pirate_mercury_open(int gd, int flags, pirate_mercury_param_t *param, mercury_ctx *ctx);
+int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *ctx);
 int pirate_mercury_close(mercury_ctx *ctx);
 ssize_t pirate_mercury_read(const pirate_mercury_param_t *param, mercury_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_mercury_write(const pirate_mercury_param_t *param, mercury_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/pipe.c
+++ b/libpirate/pipe.c
@@ -68,6 +68,21 @@ int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx) {
     return 0;
 }
 
+int pirate_pipe_pipe(int flags, pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx) {
+    (void) flags;
+    (void) param;
+    int rv, fd[2];
+
+    rv = pipe(fd);
+    if (rv < 0) {
+        return rv;
+    }
+
+    read_ctx->fd = fd[0];
+    write_ctx->fd = fd[1];
+    return 0;
+}
+
 int pirate_pipe_close(pipe_ctx *ctx) {
     int rv = -1;
 

--- a/libpirate/pipe.c
+++ b/libpirate/pipe.c
@@ -24,12 +24,6 @@
 #include "pirate_common.h"
 #include "pipe.h"
 
-static void pirate_pipe_init_param(int gd, pirate_pipe_param_t *param) {
-    if (strnlen(param->path, 1) == 0) {
-        snprintf(param->path, PIRATE_LEN_NAME - 1, PIRATE_PIPE_NAME_FMT, gd);
-    }
-}
-
 int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param) {
     char *ptr = NULL;
 
@@ -38,9 +32,11 @@ int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param) {
         return -1;
     }
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        strncpy(param->path, ptr, sizeof(param->path));
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    strncpy(param->path, ptr, sizeof(param->path));
 
     if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
         param->iov_len = strtol(ptr, NULL, 10);
@@ -49,10 +45,13 @@ int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param) {
     return 0;
 }
 
-int pirate_pipe_open(int gd, int flags, pirate_pipe_param_t *param,
-                        pipe_ctx *ctx) {
+int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx) {
     int err;
-    pirate_pipe_init_param(gd, param);
+
+    if (strnlen(param->path, 1) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
     err = errno;
     if (mkfifo(param->path, 0660) == -1) {
         if (errno == EEXIST) {
@@ -62,16 +61,11 @@ int pirate_pipe_open(int gd, int flags, pirate_pipe_param_t *param,
         }
     }
 
-    if (ctx->fd > 0) {
-        errno = EBUSY;
-        return -1;
-    }
-
     if ((ctx->fd = open(param->path, flags)) < 0) {
         return -1;
     }
 
-    return gd;
+    return 0;
 }
 
 int pirate_pipe_close(pipe_ctx *ctx) {

--- a/libpirate/pipe.h
+++ b/libpirate/pipe.h
@@ -24,7 +24,7 @@ typedef struct {
  } pipe_ctx;
 
 int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param);
-int pirate_pipe_open(int gd, int flags, pirate_pipe_param_t *param, pipe_ctx *ctx);
+int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx);
 int pirate_pipe_close(pipe_ctx *ctx);
 ssize_t pirate_pipe_read(const pirate_pipe_param_t *param, pipe_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_pipe_write(const pirate_pipe_param_t *param, pipe_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/pipe.h
+++ b/libpirate/pipe.h
@@ -24,6 +24,7 @@ typedef struct {
  } pipe_ctx;
 
 int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param);
+int pirate_pipe_pipe(int flags, pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx);
 int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx);
 int pirate_pipe_close(pipe_ctx *ctx);
 ssize_t pirate_pipe_read(const pirate_pipe_param_t *param, pipe_ctx *ctx, void *buf, size_t count);

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -32,6 +32,9 @@ typedef std::atomic_int pirate_atomic_int;
 #include <stdatomic.h>
 typedef atomic_int pirate_atomic_int;
 #define ATOMIC_INC(PTR) atomic_fetch_add(PTR, 1)
+#else
+typedef int pirate_atomic_int;
+#define ATOMIC_INC(PTR) __atomic_fetch_add(PTR, 1, __ATOMIC_SEQ_CST)
 #endif
 
 #include "libpirate.h"

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -26,10 +26,11 @@
 
 #ifdef __cplusplus
 #include <atomic>
-typedef std::atomic_int atomic_int
+typedef std::atomic_int pirate_atomic_int;
 #define ATOMIC_INC(PTR) std::atomic_fetch_add(PTR, 1)
 #elif HAVE_STD_ATOMIC
 #include <stdatomic.h>
+typedef atomic_int pirate_atomic_int;
 #define ATOMIC_INC(PTR) atomic_fetch_add(PTR, 1)
 #endif
 
@@ -152,7 +153,7 @@ int pirate_get_channel_param(int gd, pirate_channel_param_t *param) {
     return 0;
 }
 
-static atomic_int next_gd;
+static pirate_atomic_int next_gd;
 
 static int pirate_next_gd() {
     int next = ATOMIC_INC(&next_gd);

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -323,6 +323,15 @@ int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags) {
     return 0;
 }
 
+int pirate_pipe_parse(int gd[2], const char *param, int flags) {
+    pirate_channel_param_t vals;
+
+    if (pirate_parse_channel_param(param, &vals) < 0) {
+        return -1;
+    }
+
+    return pirate_pipe_param(gd, &vals, flags);
+}
 
 int pirate_close(int gd) {
     pirate_channel_t *channel;

--- a/libpirate/serial.h
+++ b/libpirate/serial.h
@@ -23,7 +23,7 @@ typedef struct {
 } serial_ctx;
 
 int pirate_serial_parse_param(char *str, pirate_serial_param_t *param);
-int pirate_serial_open(int gd, int flags, pirate_serial_param_t *param, serial_ctx *ctx);
+int pirate_serial_open(int flags, pirate_serial_param_t *param, serial_ctx *ctx);
 int pirate_serial_close(serial_ctx *ctx);
 ssize_t pirate_serial_read(const pirate_serial_param_t *param, serial_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_serial_write(const pirate_serial_param_t *param, serial_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/shmem.c
+++ b/libpirate/shmem.c
@@ -174,10 +174,7 @@ error:
     return NULL;
 }
 
-static void shmem_buffer_init_param(int gd, pirate_shmem_param_t *param) {
-    if (strnlen(param->path, 1) == 0) {
-        snprintf(param->path, PIRATE_LEN_NAME - 1, PIRATE_SHMEM_NAME_FMT, gd);
-    }
+static void shmem_buffer_init_param(pirate_shmem_param_t *param) {
     if (param->buffer_size == 0) {
         param->buffer_size = DEFAULT_SMEM_BUF_LEN;
     }
@@ -202,12 +199,12 @@ int shmem_buffer_parse_param(char *str, pirate_shmem_param_t *param) {
     return 0;
 }
 
-int shmem_buffer_open(int gd, int flags, pirate_shmem_param_t *param, shmem_ctx *ctx) {
+int shmem_buffer_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx) {
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
 
-    shmem_buffer_init_param(gd, param);
+    shmem_buffer_init_param(param);
     // on successful shm_open (fd > 0) we must shm_unlink before exiting
     // this function
     int fd = shm_open(param->path, O_RDWR | O_CREAT, 0660);
@@ -265,7 +262,7 @@ int shmem_buffer_open(int gd, int flags, pirate_shmem_param_t *param, shmem_ctx 
     }
 
     ctx->flags = flags;
-    return gd;
+    return 0;
 error:
     err = errno;
     ctx->buf = NULL;

--- a/libpirate/shmem.h
+++ b/libpirate/shmem.h
@@ -19,7 +19,7 @@
 #include "shmem_interface.h"
 
 int shmem_buffer_parse_param(char *str, pirate_shmem_param_t *param);
-int shmem_buffer_open(int gd, int flags, pirate_shmem_param_t *param, shmem_ctx *ctx);
+int shmem_buffer_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx);
 int shmem_buffer_close(shmem_ctx *ctx);
 ssize_t shmem_buffer_read(const pirate_shmem_param_t *param, shmem_ctx *ctx, void *buf, size_t count);
 ssize_t shmem_buffer_write(const pirate_shmem_param_t *param, shmem_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/shmem_buffer.h
+++ b/libpirate/shmem_buffer.h
@@ -23,7 +23,7 @@
 
 #ifdef __cplusplus
 #include <atomic>
-using namespace std;
+typedef std::atomic_uint_fast64_t atomic_uint_fast64_t
 #elif HAVE_STD_ATOMIC
 #include <stdatomic.h>
 #else

--- a/libpirate/shmem_buffer.h
+++ b/libpirate/shmem_buffer.h
@@ -23,20 +23,21 @@
 
 #ifdef __cplusplus
 #include <atomic>
-typedef std::atomic_uint_fast64_t atomic_uint_fast64_t
+typedef std::atomic_uint_fast64_t pirate_atomic_uint64;
 #elif HAVE_STD_ATOMIC
 #include <stdatomic.h>
+typedef atomic_uint_fast64_t pirate_atomic_uint64;
 #else
 // This is a workaround.
 // Do not use shmem_buffer_t when atomics are not available
-typedef uint_fast64_t atomic_uint_fast64_t;
+typedef uint_fast64_t pirate_atomic_uint64;
 #endif
 
 typedef struct {
-    atomic_uint_fast64_t    position;
-    atomic_uint_fast64_t    init;
-    atomic_uint_fast64_t    reader_pid;
-    atomic_uint_fast64_t    writer_pid;
+    pirate_atomic_uint64    position;
+    pirate_atomic_uint64    init;
+    pirate_atomic_uint64    reader_pid;
+    pirate_atomic_uint64    writer_pid;
     sem_t                   reader_open_wait;
     sem_t                   writer_open_wait;
     pthread_mutex_t         mutex;

--- a/libpirate/shmem_interface.c
+++ b/libpirate/shmem_interface.c
@@ -28,11 +28,11 @@ int pirate_shmem_parse_param(char *str, pirate_shmem_param_t *param) {
 #endif
 }
 
-int pirate_shmem_open(int gd, int flags, pirate_shmem_param_t *param, shmem_ctx *ctx) {
+int pirate_shmem_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx) {
 #ifdef PIRATE_SHMEM_FEATURE
-    return shmem_buffer_open(gd, flags, param, ctx);
+    return shmem_buffer_open(flags, param, ctx);
 #else
-    (void) gd, (void) flags, (void) param, (void) ctx;
+    (void) flags, (void) param, (void) ctx;
     errno = ESOCKTNOSUPPORT;
     return -1;
 #endif

--- a/libpirate/shmem_interface.h
+++ b/libpirate/shmem_interface.h
@@ -25,7 +25,7 @@ typedef struct {
 } shmem_ctx;
 
 int pirate_shmem_parse_param(char *str, pirate_shmem_param_t *param);
-int pirate_shmem_open(int gd, int flags, pirate_shmem_param_t *param, shmem_ctx *ctx);
+int pirate_shmem_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx);
 int pirate_shmem_close(shmem_ctx *ctx);
 ssize_t pirate_shmem_read(const pirate_shmem_param_t *param, shmem_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_shmem_write(const pirate_shmem_param_t *param, shmem_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/tcp_socket.c
+++ b/libpirate/tcp_socket.c
@@ -181,15 +181,16 @@ static int tcp_socket_writer_open(pirate_tcp_socket_param_t *param, tcp_socket_c
 
 int pirate_tcp_socket_open(int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
 
     pirate_tcp_socket_init_param(param);
     if (param->port <= 0) {
         errno = EINVAL;
         return -1;
     }
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = tcp_socket_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else {
         rv = tcp_socket_writer_open(param, ctx);
     }
 

--- a/libpirate/tcp_socket.c
+++ b/libpirate/tcp_socket.c
@@ -26,12 +26,9 @@
 #include "pirate_common.h"
 #include "tcp_socket.h"
 
-static void pirate_tcp_socket_init_param(int gd, pirate_tcp_socket_param_t *param) {
+static void pirate_tcp_socket_init_param(pirate_tcp_socket_param_t *param) {
     if (strnlen(param->addr, 1) == 0) {
         snprintf(param->addr, sizeof(param->addr) - 1, DEFAULT_TCP_IP_ADDR);
-    }
-    if (param->port == 0) {
-        param->port = PIRATE_TCP_PORT_BASE + gd;
     }
 }
 
@@ -43,13 +40,17 @@ int pirate_tcp_socket_parse_param(char *str, pirate_tcp_socket_param_t *param) {
         return -1;
     }
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        strncpy(param->addr, ptr, sizeof(param->addr));
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    strncpy(param->addr, ptr, sizeof(param->addr));
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        param->port = strtol(ptr, NULL, 10);
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    param->port = strtol(ptr, NULL, 10);
     
     if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
         param->iov_len = strtol(ptr, NULL, 10);
@@ -178,17 +179,21 @@ static int tcp_socket_writer_open(pirate_tcp_socket_param_t *param, tcp_socket_c
     return -1;
 }
 
-int pirate_tcp_socket_open(int gd, int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx) {
+int pirate_tcp_socket_open(int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx) {
     int rv = -1;
 
-    pirate_tcp_socket_init_param(gd, param);
+    pirate_tcp_socket_init_param(param);
+    if (param->port <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
     if (flags == O_RDONLY) {
         rv = tcp_socket_reader_open(param, ctx);
     } else if (flags == O_WRONLY) {
         rv = tcp_socket_writer_open(param, ctx);
     }
 
-    return rv == 0 ? gd : rv;
+    return rv;
 }
 
 int pirate_tcp_socket_close(tcp_socket_ctx *ctx) {

--- a/libpirate/tcp_socket.h
+++ b/libpirate/tcp_socket.h
@@ -23,7 +23,7 @@ typedef struct {
 } tcp_socket_ctx;
 
 int pirate_tcp_socket_parse_param(char *str, pirate_tcp_socket_param_t *param);
-int pirate_tcp_socket_open(int gd, int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx);
+int pirate_tcp_socket_open(int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx);
 int pirate_tcp_socket_close(tcp_socket_ctx *ctx);
 ssize_t pirate_tcp_socket_read(const pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_tcp_socket_write(const pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/test/channel_test.cpp
+++ b/libpirate/test/channel_test.cpp
@@ -104,7 +104,9 @@ void ChannelTest::ReaderChannelClose()
 void ChannelTest::Run()
 {
     RunChildOpen(true);
-    RunChildOpen(false);
+    if (pirate_pipe_channel_type(param.channel_type)) {
+        RunChildOpen(false);
+    }
 }
 
 void ChannelTest::RunChildOpen(bool child)

--- a/libpirate/test/channel_test.cpp
+++ b/libpirate/test/channel_test.cpp
@@ -72,30 +72,30 @@ void ChannelTest::WriteDataInit(ssize_t len)
 
 void ChannelTest::WriterChannelOpen()
 {
-    int rv = pirate_open(Writer.channel, O_WRONLY);
-    ASSERT_EQ(Writer.channel, rv);
+    Writer.channel = pirate_open_param(&param, O_WRONLY);
     ASSERT_EQ(0, errno);
-}
+    ASSERT_GE(Writer.channel, 0);
+ }
 
 void ChannelTest::ReaderChannelOpen()
 {
-    int rv = pirate_open(Reader.channel, O_RDONLY);
-    ASSERT_EQ(Reader.channel, rv);
+    Reader.channel = pirate_open_param(&param, O_RDONLY);
     ASSERT_EQ(0, errno);
+    ASSERT_GE(Reader.channel, 0);
 }
 
 void ChannelTest::WriterChannelClose()
 {
     int rv = pirate_close(Writer.channel, O_WRONLY);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
 }
 
 void ChannelTest::ReaderChannelClose()
 {
     int rv = pirate_close(Reader.channel, O_RDONLY);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
 }
 
 void ChannelTest::Run()
@@ -116,10 +116,10 @@ void ChannelTest::RunChildOpen(bool child)
 
     if (!childOpen)
     {
-        ASSERT_EQ(Reader.channel, Writer.channel);
-        rv = pirate_pipe(Writer.channel, O_RDWR);
-        ASSERT_EQ(Writer.channel, rv);
+        Writer.channel = pirate_pipe_param(&param, O_RDWR);
+        Reader.channel = Writer.channel;
         ASSERT_EQ(0, errno);
+        ASSERT_GE(Writer.channel, 0);
     }
 
     rv = pthread_create(&ReaderId, NULL, ChannelTest::ReaderThreadS, this);
@@ -207,8 +207,8 @@ void ChannelTest::ReaderTest()
         uint8_t *buf = Reader.buf;
         do {
             rv = pirate_read(Reader.channel, buf, remain);
-            ASSERT_GT(rv, 0);
             ASSERT_EQ(0, errno);
+            ASSERT_GT(rv, 0);
             remain -= rv;
             buf += rv;
 

--- a/libpirate/test/common_test.cpp
+++ b/libpirate/test/common_test.cpp
@@ -24,24 +24,15 @@ namespace GAPS {
 
 TEST(CommonChannel, InvalidOpen)
 {
+    pirate_channel_param_t param;
     int rv;
 
-    // Invalid channel number - negative
-    rv = pirate_open(-1, O_WRONLY);
-    ASSERT_EQ(-1, rv);
-    ASSERT_EQ(EBADF, errno);
-    errno = 0;
-
-    // Invalid channel number - exceeds bound
-    rv = pirate_open(PIRATE_NUM_CHANNELS, O_WRONLY);
-    ASSERT_EQ(-1, rv);
-    ASSERT_EQ(EBADF, errno);
-    errno = 0;
+    pirate_init_channel_param(PIPE, &param);
 
     // Invalid flags
-    rv = pirate_open(ChannelTest::TEST_CHANNEL, O_RDWR);
-    ASSERT_EQ(-1, rv);
+    rv = pirate_open_param(&param, O_RDWR);
     ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 }
 
@@ -51,26 +42,26 @@ TEST(CommonChannel, InvalidCLose)
 
     // Invalid channel number - negative
     rv = pirate_close(-1, O_WRONLY);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(EBADF, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 
     // Invalid channel number - exceeds bound
     rv = pirate_close(PIRATE_NUM_CHANNELS, O_WRONLY);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(EBADF, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 
     // Invalid flags
     rv = pirate_close(ChannelTest::TEST_CHANNEL, O_RDWR);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 
     // Close unopened channel
     rv = pirate_close(ChannelTest::TEST_CHANNEL, O_WRONLY);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(ENODEV, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 }
 

--- a/libpirate/test/common_test.cpp
+++ b/libpirate/test/common_test.cpp
@@ -41,26 +41,20 @@ TEST(CommonChannel, InvalidCLose)
     int rv;
 
     // Invalid channel number - negative
-    rv = pirate_close(-1, O_WRONLY);
+    rv = pirate_close(-1);
     ASSERT_EQ(EBADF, errno);
     ASSERT_EQ(-1, rv);
     errno = 0;
 
     // Invalid channel number - exceeds bound
-    rv = pirate_close(PIRATE_NUM_CHANNELS, O_WRONLY);
+    rv = pirate_close(PIRATE_NUM_CHANNELS);
     ASSERT_EQ(EBADF, errno);
     ASSERT_EQ(-1, rv);
     errno = 0;
 
-    // Invalid flags
-    rv = pirate_close(ChannelTest::TEST_CHANNEL, O_RDWR);
-    ASSERT_EQ(EINVAL, errno);
-    ASSERT_EQ(-1, rv);
-    errno = 0;
-
     // Close unopened channel
-    rv = pirate_close(ChannelTest::TEST_CHANNEL, O_WRONLY);
-    ASSERT_EQ(ENODEV, errno);
+    rv = pirate_close(ChannelTest::TEST_CHANNEL);
+    ASSERT_EQ(EBADF, errno);
     ASSERT_EQ(-1, rv);
     errno = 0;
 }
@@ -74,13 +68,13 @@ TEST(CommonChannel, InvalidReadWrite)
     // Read unopened channel
     rv = pirate_read(ChannelTest::TEST_CHANNEL, buf, sizeof(buf));
     ASSERT_EQ(-1, rv);
-    ASSERT_EQ(ENODEV, errno);
+    ASSERT_EQ(EBADF, errno);
     errno = 0;
 
     // Write unopened channel
     rv = pirate_write(ChannelTest::TEST_CHANNEL, buf, sizeof(buf));
     ASSERT_EQ(-1, rv);
-    ASSERT_EQ(ENODEV, errno);
+    ASSERT_EQ(EBADF, errno);
     errno = 0;
 }
 

--- a/libpirate/test/device_test.cpp
+++ b/libpirate/test/device_test.cpp
@@ -42,17 +42,17 @@ TEST(ChannelDeviceTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);
+    ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
     ASSERT_EQ(DEVICE, param.channel_type);
-    ASSERT_EQ(0, errno);
     ASSERT_STREQ(path, device_param->path);
     ASSERT_EQ(0u, device_param->iov_len);
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u", name, path, iov_len);
     rv = pirate_parse_channel_param(opt, &param);
+    ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
     ASSERT_EQ(DEVICE, param.channel_type);
-    ASSERT_EQ(0, errno);
     ASSERT_STREQ(path, device_param->path);
     ASSERT_EQ(iov_len, device_param->iov_len);
 }
@@ -61,7 +61,6 @@ class DeviceTest : public ChannelTest, public WithParamInterface<int>
 {
 public:
     void ChannelInit() {
-        int rv;
         pirate_init_channel_param(DEVICE, &param);
         snprintf(param.channel.device.path, PIRATE_LEN_NAME - 1, "/tmp/gaps_dev");
         param.channel.device.iov_len = GetParam();
@@ -70,14 +69,6 @@ public:
             ASSERT_EQ(EEXIST, errno);
             errno = 0;
         }
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 };
 

--- a/libpirate/test/ge_eth_test.cpp
+++ b/libpirate/test/ge_eth_test.cpp
@@ -36,26 +36,20 @@ TEST(ChannelGeEthTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(GE_ETH, param.channel_type);
-    ASSERT_STREQ("", ge_eth_param->addr);
-    ASSERT_EQ(0, ge_eth_param->port);
-    ASSERT_EQ(0u, ge_eth_param->mtu);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, addr);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(GE_ETH, param.channel_type);
-    ASSERT_STREQ(addr, ge_eth_param->addr);
-    ASSERT_EQ(0, ge_eth_param->port);
-    ASSERT_EQ(0u, ge_eth_param->mtu);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%d", name, addr, port);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(GE_ETH, param.channel_type);
     ASSERT_STREQ(addr, ge_eth_param->addr);
     ASSERT_EQ(port, ge_eth_param->port);
@@ -76,26 +70,16 @@ class GeEthTest : public ChannelTest, public WithParamInterface<unsigned>
 public:
     void ChannelInit()
     {
-        int rv;
-
         // Since UDP is unreliable it's possible to get out of sync.
         // Use write delay to reduce the chance of that
         WriteDelayUs = 1000;
 
         pirate_init_channel_param(GE_ETH, &param);
+        param.channel.ge_eth.port = 0x4745;
         const unsigned mtu = GetParam();
         if (mtu) {
             param.channel.ge_eth.mtu = mtu;
         }
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     static const unsigned TEST_MTU_LEN = DEFAULT_GE_ETH_MTU / 2;

--- a/libpirate/test/mercury_test.cpp
+++ b/libpirate/test/mercury_test.cpp
@@ -41,26 +41,26 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &rdParam);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
     
     snprintf(opt, sizeof(opt) - 1, "%s,%u", name, level);
     rv = pirate_parse_channel_param(opt, &rdParam);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
  
     snprintf(opt, sizeof(opt) - 1, "%s,%u,%u", name, level, src_id);
     rv = pirate_parse_channel_param(opt, &rdParam);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%u,%u,%u", name, level, src_id, dst_id);
     rv = pirate_parse_channel_param(opt, &rdParam);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     expParam.channel.mercury.session.level = level;
     expParam.channel.mercury.session.source_id = src_id;
     expParam.channel.mercury.session.destination_id = dst_id;
@@ -71,16 +71,16 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
     snprintf(opt, sizeof(opt) - 1, "%s,%u,%u,%u,%u", name, level, src_id,
             dst_id, timeout_ms);
     rv = pirate_parse_channel_param(opt, &rdParam);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     expParam.channel.mercury.timeout_ms = timeout_ms;
     EXPECT_TRUE(0 == std::memcmp(&expParam, &rdParam, sizeof(rdParam)));
 
     snprintf(opt, sizeof(opt) - 1, "%s,%u,%u,%u,%u,%u", name, level, src_id,
             dst_id, timeout_ms, msg_ids[0]);
     rv = pirate_parse_channel_param(opt, &rdParam);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     expParam.channel.mercury.session.message_count = 1;
     expParam.channel.mercury.session.messages[0] = msg_ids[0];
     EXPECT_TRUE(0 == std::memcmp(&expParam, &rdParam, sizeof(rdParam)));
@@ -88,8 +88,8 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
     snprintf(opt, sizeof(opt) - 1, "%s,%u,%u,%u,%u,%u,%u", name, level, src_id,
             dst_id, timeout_ms, msg_ids[0], msg_ids[1]);
     rv = pirate_parse_channel_param(opt, &rdParam);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     expParam.channel.mercury.session.message_count = 2;
     expParam.channel.mercury.session.messages[1] = msg_ids[1];
     EXPECT_TRUE(0 == std::memcmp(&expParam, &rdParam, sizeof(rdParam)));
@@ -106,7 +106,7 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
 
 TEST(ChannelMercuryTest, DefaultSession) {
     int rv = 0;
-    const int channel = 0;
+    int rchannel, wchannel;
 
     const uint32_t session_id = 1;
     const uint8_t wr_data[] = { 0xC0, 0xDE, 0xDA, 0xDA };
@@ -125,40 +125,33 @@ TEST(ChannelMercuryTest, DefaultSession) {
     pirate_channel_param_t param;
     pirate_init_channel_param(MERCURY, &param);
 
-    rv =  pirate_set_channel_param(channel, O_WRONLY, &param);
-    ASSERT_EQ(0, rv);
+    wchannel = pirate_open_param(&param, O_WRONLY);
     ASSERT_EQ(0, errno);
+    ASSERT_GE(wchannel, 0);
 
-    rv =  pirate_set_channel_param(channel, O_RDONLY, &param);
-    ASSERT_EQ(0, rv);
+
+    rchannel = pirate_open_param(&param, O_RDONLY);
     ASSERT_EQ(0, errno);
+    ASSERT_GE(rchannel, 0);
 
-    rv = pirate_open(channel, O_WRONLY);
-    ASSERT_EQ(channel, rv);
-    ASSERT_EQ(0, errno);
-
-    rv = pirate_open(channel, O_RDONLY);
-    ASSERT_EQ(channel, rv);
-    ASSERT_EQ(0, errno);
-
-    rv = pirate_get_channel_param(channel, O_WRONLY, &param);
+    rv = pirate_get_channel_param(wchannel, O_WRONLY, &param);
     ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
     ASSERT_EQ(session_id, param.channel.mercury.session.id);
 
-    io_size = pirate_write(channel, wr_data, data_len);
-    ASSERT_EQ(io_size, data_len);
+    io_size = pirate_write(wchannel, wr_data, data_len);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(io_size, data_len);
 
-    io_size = pirate_read(channel, rd_data, data_len);
-    ASSERT_EQ(io_size, data_len);
+    io_size = pirate_read(rchannel, rd_data, data_len);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(io_size, data_len);
 
     EXPECT_TRUE(0 == std::memcmp(wr_data, rd_data, data_len));
 
     rv = mercury_cmd_stat(session_id, &stats);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
 
     ASSERT_EQ(1u, stats.send_count);
     ASSERT_EQ(1u, stats.receive_count);
@@ -170,12 +163,12 @@ TEST(ChannelMercuryTest, DefaultSession) {
     ASSERT_EQ(0u, stats.receive_ilip_reject_count);
 
     rv = mercury_cmd_stat_clear(session_id);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
 
     rv = mercury_cmd_stat(session_id, &stats);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
 
     ASSERT_EQ(0u, stats.send_count);
     ASSERT_EQ(0u, stats.receive_count);
@@ -186,13 +179,14 @@ TEST(ChannelMercuryTest, DefaultSession) {
     ASSERT_EQ(0u, stats.send_ilip_reject_count);
     ASSERT_EQ(0u, stats.receive_ilip_reject_count);
 
-    rv = pirate_close(channel, O_WRONLY);
-    ASSERT_EQ(0, rv);
+    rv = pirate_close(wchannel, O_WRONLY);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
 
-    rv = pirate_close(channel, O_RDONLY);
-    ASSERT_EQ(0, rv);
+
+    rv = pirate_close(rchannel, O_RDONLY);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
 }
 
 
@@ -213,7 +207,6 @@ public:
     {
         WriteDelayUs = 10000;
 
-        int rv;
         mMercuryParam = GetParam();
         Writer.channel = Reader.channel = mMercuryParam.channel;
 
@@ -226,35 +219,20 @@ public:
         for (uint32_t i = 0; i < param.channel.mercury.session.message_count; ++i) {
             param.channel.mercury.session.messages[i] = mMercuryParam.messages[i];
         }
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // Reader
-        pirate_init_channel_param(MERCURY, &param);
-        param.channel.mercury.session.level          = mMercuryParam.level;
-        param.channel.mercury.session.source_id      = mMercuryParam.source_id;
-        param.channel.mercury.session.destination_id = mMercuryParam.destination_id;
-        param.channel.mercury.session.message_count  = mMercuryParam.message_count;
-        for (uint32_t i = 0; i < param.channel.mercury.session.message_count; ++i) {
-            param.channel.mercury.session.messages[i] = mMercuryParam.messages[i];
-        }
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     void WriterChannelOpen() override
     {
         pirate_channel_param_t rdParam;
 
-        int rv = pirate_open(Writer.channel, O_WRONLY);
-        ASSERT_EQ(Writer.channel, rv);
+        Writer.channel = pirate_open_param(&param, O_WRONLY);
         ASSERT_EQ(0, errno);
+        ASSERT_GE(Writer.channel, 0);
 
-        rv = pirate_get_channel_param(Writer.channel, O_WRONLY, &rdParam);
-        ASSERT_EQ(0, rv);
+
+        int rv = pirate_get_channel_param(Writer.channel, O_WRONLY, &rdParam);
         ASSERT_EQ(0, errno);
+        ASSERT_EQ(0, rv);
 
         ASSERT_EQ(MERCURY, rdParam.channel_type);
         ASSERT_EQ(mMercuryParam.session_id, rdParam.channel.mercury.session.id);
@@ -268,11 +246,11 @@ public:
     {
         pirate_channel_param_t rdParam;
 
-        int rv = pirate_open(Reader.channel, O_RDONLY);
-        ASSERT_EQ(Reader.channel, rv);
+        Reader.channel = pirate_open_param(&param, O_RDONLY);
+        ASSERT_GE(Reader.channel, 0);
         ASSERT_EQ(0, errno);
 
-        rv = pirate_get_channel_param(Writer.channel, O_RDONLY, &rdParam);
+        int rv = pirate_get_channel_param(Reader.channel, O_RDONLY, &rdParam);
         ASSERT_EQ(0, rv);
         ASSERT_EQ(0, errno);
 

--- a/libpirate/test/mercury_test.cpp
+++ b/libpirate/test/mercury_test.cpp
@@ -134,7 +134,7 @@ TEST(ChannelMercuryTest, DefaultSession) {
     ASSERT_EQ(0, errno);
     ASSERT_GE(rchannel, 0);
 
-    rv = pirate_get_channel_param(wchannel, O_WRONLY, &param);
+    rv = pirate_get_channel_param(wchannel, &param);
     ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
     ASSERT_EQ(session_id, param.channel.mercury.session.id);
@@ -179,12 +179,12 @@ TEST(ChannelMercuryTest, DefaultSession) {
     ASSERT_EQ(0u, stats.send_ilip_reject_count);
     ASSERT_EQ(0u, stats.receive_ilip_reject_count);
 
-    rv = pirate_close(wchannel, O_WRONLY);
+    rv = pirate_close(wchannel);
     ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
 
 
-    rv = pirate_close(rchannel, O_RDONLY);
+    rv = pirate_close(rchannel);
     ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
 }
@@ -230,7 +230,7 @@ public:
         ASSERT_GE(Writer.channel, 0);
 
 
-        int rv = pirate_get_channel_param(Writer.channel, O_WRONLY, &rdParam);
+        int rv = pirate_get_channel_param(Writer.channel, &rdParam);
         ASSERT_EQ(0, errno);
         ASSERT_EQ(0, rv);
 
@@ -250,7 +250,7 @@ public:
         ASSERT_GE(Reader.channel, 0);
         ASSERT_EQ(0, errno);
 
-        int rv = pirate_get_channel_param(Reader.channel, O_RDONLY, &rdParam);
+        int rv = pirate_get_channel_param(Reader.channel, &rdParam);
         ASSERT_EQ(0, rv);
         ASSERT_EQ(0, errno);
 

--- a/libpirate/test/mercury_test.cpp
+++ b/libpirate/test/mercury_test.cpp
@@ -107,7 +107,7 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
 TEST(ChannelMercuryTest, DefaultSession) {
     int rv = 0;
     int rchannel, wchannel;
-
+    pirate_channel_param_t param;
     const uint32_t session_id = 1;
     const uint8_t wr_data[] = { 0xC0, 0xDE, 0xDA, 0xDA };
     const ssize_t data_len = sizeof(wr_data);
@@ -122,17 +122,20 @@ TEST(ChannelMercuryTest, DefaultSession) {
         return;
     }
 
-    pirate_channel_param_t param;
     pirate_init_channel_param(MERCURY, &param);
-
     wchannel = pirate_open_param(&param, O_WRONLY);
     ASSERT_EQ(0, errno);
     ASSERT_GE(wchannel, 0);
 
-
+    pirate_init_channel_param(MERCURY, &param);
     rchannel = pirate_open_param(&param, O_RDONLY);
     ASSERT_EQ(0, errno);
     ASSERT_GE(rchannel, 0);
+
+    rv = pirate_get_channel_param(wchannel, &param);
+    ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
+    ASSERT_EQ(session_id, param.channel.mercury.session.id);
 
     rv = pirate_get_channel_param(wchannel, &param);
     ASSERT_EQ(0, errno);
@@ -182,7 +185,6 @@ TEST(ChannelMercuryTest, DefaultSession) {
     rv = pirate_close(wchannel);
     ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
-
 
     rv = pirate_close(rchannel);
     ASSERT_EQ(0, errno);

--- a/libpirate/test/pipe_test.cpp
+++ b/libpirate/test/pipe_test.cpp
@@ -37,24 +37,22 @@ TEST(ChannelPipeTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(PIPE, param.channel_type);
-    ASSERT_STREQ("", pipe_param->path);
-    ASSERT_EQ(0u, pipe_param->iov_len);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(PIPE, param.channel_type);
     ASSERT_STREQ(path, pipe_param->path);
     ASSERT_EQ(0u, pipe_param->iov_len);
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u", name, path, iov_len);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(PIPE, param.channel_type);
     ASSERT_STREQ(path, pipe_param->path);
     ASSERT_EQ(iov_len, pipe_param->iov_len);
@@ -65,19 +63,9 @@ class PipeTest : public ChannelTest, public WithParamInterface<int>
 public:
     void ChannelInit()
     {
-        int rv;
-
         pirate_init_channel_param(PIPE, &param);
+        strncpy(param.channel.pipe.path, "/tmp/gaps.channel.test", PIRATE_LEN_NAME);
         param.channel.pipe.iov_len = GetParam();
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // Write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 };
 

--- a/libpirate/test/serial_test.cpp
+++ b/libpirate/test/serial_test.cpp
@@ -39,17 +39,14 @@ TEST(ChannelSerialTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(SERIAL, param.channel_type);
-    ASSERT_STREQ("", serial_param->path);
-    ASSERT_EQ((speed_t)0, serial_param->baud);
-    ASSERT_EQ(0u, serial_param->mtu);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(SERIAL, param.channel_type);
     ASSERT_STREQ(path, serial_param->path);
     ASSERT_EQ((speed_t)0, serial_param->baud);
@@ -57,8 +54,8 @@ TEST(ChannelSerialTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%s", name, path, baud_str);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(SERIAL, param.channel_type);
     ASSERT_STREQ(path, serial_param->path);
     ASSERT_EQ(baud, serial_param->baud);
@@ -66,8 +63,8 @@ TEST(ChannelSerialTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%s,%u", name, path, baud_str, mtu);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(SERIAL, param.channel_type);
     ASSERT_STREQ(path, serial_param->path);
     ASSERT_EQ(baud, serial_param->baud);
@@ -76,8 +73,8 @@ TEST(ChannelSerialTest, ConfigurationParser) {
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%s,%u", name, path,
                 invalid_baud_str, mtu);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 }
 
@@ -87,46 +84,22 @@ class SerialTest : public ChannelTest,
 public:
     void ChannelInit()
     {
-        Writer.channel = 0;
-        Reader.channel = 1;
-
         auto test_param = GetParam();
         const speed_t baud = std::get<0>(test_param);
         const unsigned mtu = std::get<0>(test_param);
-        int rv;
 
-        pirate_init_channel_param(SERIAL, &wr_param);
+        pirate_init_channel_param(SERIAL, &param);
         if (baud) {
-            wr_param.channel.serial.baud = baud;
+            param.channel.serial.baud = baud;
         }
 
         if (mtu) {
-            wr_param.channel.serial.mtu = mtu;
+            param.channel.serial.mtu = mtu;
         }
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &wr_param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        pirate_init_channel_param(SERIAL, &rd_param);
-        if (baud) {
-            rd_param.channel.serial.baud = baud;
-        }
-
-        if (mtu) {
-            rd_param.channel.serial.mtu = mtu;
-        }
-
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &rd_param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     static const speed_t TEST_BAUD = B115200;
     static const unsigned TEST_MTU = SERIAL_DEFAULT_MTU / 2;
-
-    pirate_channel_param_t wr_param;
-    pirate_channel_param_t rd_param;
 };
 
 

--- a/libpirate/test/shmem_test.cpp
+++ b/libpirate/test/shmem_test.cpp
@@ -73,7 +73,6 @@ class ShmemTest : public ChannelTest, public WithParamInterface<int>
 public:
     void ChannelInit()
     {
-        int rv;
         pirate_init_channel_param(SHMEM, &param);
         unsigned buffer_size = GetParam();
         if (buffer_size) {

--- a/libpirate/test/shmem_test.cpp
+++ b/libpirate/test/shmem_test.cpp
@@ -79,15 +79,6 @@ public:
         if (buffer_size) {
             param.channel.shmem.buffer_size = buffer_size;
         }
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     static const int TEST_BUF_LEN = DEFAULT_SMEM_BUF_LEN / 2;

--- a/libpirate/test/shmem_test.cpp
+++ b/libpirate/test/shmem_test.cpp
@@ -73,7 +73,10 @@ class ShmemTest : public ChannelTest, public WithParamInterface<int>
 public:
     void ChannelInit()
     {
+        const char *testPath = "/gaps.shmem_test";
         pirate_init_channel_param(SHMEM, &param);
+        strncpy(param.channel.shmem.path, testPath, PIRATE_LEN_NAME - 1);
+
         unsigned buffer_size = GetParam();
         if (buffer_size) {
             param.channel.shmem.buffer_size = buffer_size;

--- a/libpirate/test/tcp_socket_test.cpp
+++ b/libpirate/test/tcp_socket_test.cpp
@@ -37,28 +37,20 @@ TEST(ChannelTcpSocketTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(TCP_SOCKET, param.channel_type);
-    ASSERT_STREQ("", tcp_socket_param->addr);
-    ASSERT_EQ(0, tcp_socket_param->port);
-    ASSERT_EQ(0u, tcp_socket_param->iov_len);
-    ASSERT_EQ(0u, tcp_socket_param->buffer_size);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, addr);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(TCP_SOCKET, param.channel_type);
-    ASSERT_STREQ(addr, tcp_socket_param->addr);
-    ASSERT_EQ(0, tcp_socket_param->port);
-    ASSERT_EQ(0u, tcp_socket_param->iov_len);
-    ASSERT_EQ(0u, tcp_socket_param->buffer_size);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u", name, addr, port);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(TCP_SOCKET, param.channel_type);
     ASSERT_STREQ(addr, tcp_socket_param->addr);
     ASSERT_EQ(port, tcp_socket_param->port);
@@ -67,8 +59,8 @@ TEST(ChannelTcpSocketTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u,%u", name, addr, port, iov_len);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(TCP_SOCKET, param.channel_type);
     ASSERT_STREQ(addr, tcp_socket_param->addr);
     ASSERT_EQ(port, tcp_socket_param->port);
@@ -78,8 +70,8 @@ TEST(ChannelTcpSocketTest, ConfigurationParser) {
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u,%u,%u", name, addr, port, iov_len,
             buffer_size);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(TCP_SOCKET, param.channel_type);
     ASSERT_STREQ(addr, tcp_socket_param->addr);
     ASSERT_EQ(port, tcp_socket_param->port);
@@ -93,20 +85,11 @@ class TcpSocketTest : public ChannelTest,
 public:
     void ChannelInit()
     {
-        int rv;
         pirate_init_channel_param(TCP_SOCKET, &param);
+        param.channel.tcp_socket.port = 26427;
         auto test_param = GetParam();
         param.channel.tcp_socket.iov_len = std::get<0>(test_param);
         param.channel.tcp_socket.buffer_size = std::get<1>(test_param);
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     static const unsigned TEST_BUF_LEN = 4096;

--- a/libpirate/test/udp_shmem_test.cpp
+++ b/libpirate/test/udp_shmem_test.cpp
@@ -40,13 +40,9 @@ TEST(ChannelUdpShmemTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(UDP_SHMEM, param.channel_type);
-    ASSERT_STREQ("", udp_shmem_param->path);
-    ASSERT_EQ(0u, udp_shmem_param->buffer_size);
-    ASSERT_EQ(0u, udp_shmem_param->packet_count);
-    ASSERT_EQ(0u, udp_shmem_param->packet_size);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);

--- a/libpirate/test/udp_shmem_test.cpp
+++ b/libpirate/test/udp_shmem_test.cpp
@@ -106,7 +106,6 @@ class UdpShmemTest : public ChannelTest,
 public:
     void ChannelInit()
     {
-        int rv;
         pirate_init_channel_param(UDP_SHMEM, &param);
         auto test_param = GetParam();
         unsigned buffer_size = std::get<0>(test_param);

--- a/libpirate/test/udp_shmem_test.cpp
+++ b/libpirate/test/udp_shmem_test.cpp
@@ -102,7 +102,9 @@ class UdpShmemTest : public ChannelTest,
 public:
     void ChannelInit()
     {
+        const char *testPath = "/gaps.shmem_test";
         pirate_init_channel_param(UDP_SHMEM, &param);
+        strncpy(param.channel.udp_shmem.path, testPath, PIRATE_LEN_NAME - 1);
         auto test_param = GetParam();
         unsigned buffer_size = std::get<0>(test_param);
         unsigned packet_count = std::get<1>(test_param);

--- a/libpirate/test/udp_shmem_test.cpp
+++ b/libpirate/test/udp_shmem_test.cpp
@@ -40,8 +40,8 @@ TEST(ChannelUdpShmemTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UDP_SHMEM, param.channel_type);
     ASSERT_STREQ("", udp_shmem_param->path);
     ASSERT_EQ(0u, udp_shmem_param->buffer_size);
@@ -50,8 +50,8 @@ TEST(ChannelUdpShmemTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UDP_SHMEM, param.channel_type);
     ASSERT_STREQ(path, udp_shmem_param->path);
     ASSERT_EQ(0u, udp_shmem_param->buffer_size);
@@ -60,8 +60,8 @@ TEST(ChannelUdpShmemTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u", name, path, buffer_size);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UDP_SHMEM, param.channel_type);
     ASSERT_STREQ(path, udp_shmem_param->path);
     ASSERT_EQ(buffer_size, udp_shmem_param->buffer_size);
@@ -82,8 +82,8 @@ TEST(ChannelUdpShmemTest, ConfigurationParser) {
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u,%u,%u", name, path, buffer_size,
                 packet_size, packet_count);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UDP_SHMEM, param.channel_type);
     ASSERT_STREQ(path, udp_shmem_param->path);
     ASSERT_EQ(buffer_size, udp_shmem_param->buffer_size);
@@ -124,15 +124,6 @@ public:
         if (packet_size) {
             param.channel.udp_shmem.packet_size = packet_size;
         }
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     static const int TEST_BUF_LEN = DEFAULT_SMEM_BUF_LEN / 2;

--- a/libpirate/test/udp_socket_test.cpp
+++ b/libpirate/test/udp_socket_test.cpp
@@ -38,28 +38,20 @@ TEST(ChannelUdpSocketTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(UDP_SOCKET, param.channel_type);
-    ASSERT_STREQ("", udp_socket_param->addr);
-    ASSERT_EQ(0, udp_socket_param->port);
-    ASSERT_EQ(0u, udp_socket_param->iov_len);
-    ASSERT_EQ(0u, udp_socket_param->buffer_size);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, addr);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(UDP_SOCKET, param.channel_type);
-    ASSERT_STREQ(addr, udp_socket_param->addr);
-    ASSERT_EQ(0, udp_socket_param->port);
-    ASSERT_EQ(0u, udp_socket_param->iov_len);
-    ASSERT_EQ(0u, udp_socket_param->buffer_size);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u", name, addr, port);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UDP_SOCKET, param.channel_type);
     ASSERT_STREQ(addr, udp_socket_param->addr);
     ASSERT_EQ(port, udp_socket_param->port);
@@ -68,8 +60,8 @@ TEST(ChannelUdpSocketTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u,%u", name, addr, port, iov_len);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UDP_SOCKET, param.channel_type);
     ASSERT_STREQ(addr, udp_socket_param->addr);
     ASSERT_EQ(port, udp_socket_param->port);
@@ -79,8 +71,8 @@ TEST(ChannelUdpSocketTest, ConfigurationParser) {
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u,%u,%u", name, addr, port, iov_len,
             buffer_size);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UDP_SOCKET, param.channel_type);
     ASSERT_STREQ(addr, udp_socket_param->addr);
     ASSERT_EQ(port, udp_socket_param->port);
@@ -98,20 +90,11 @@ public:
         // Use write delay to reduce the chance of that
         WriteDelayUs = 1000;
 
-        int rv;
         pirate_init_channel_param(UDP_SOCKET, &param);
+        param.channel.udp_socket.port = 26427;
         auto test_param = GetParam();
         param.channel.udp_socket.iov_len = std::get<0>(test_param);
         param.channel.udp_socket.buffer_size = std::get<1>(test_param);
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     static const int TEST_BUF_LEN = 4096;

--- a/libpirate/test/uio_test.cpp
+++ b/libpirate/test/uio_test.cpp
@@ -31,22 +31,22 @@ TEST(ChannelUioTest, ConfigurationParser) {
     const pirate_uio_param_t *uio_param = &param.channel.uio;
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UIO_DEVICE, param.channel_type);
     ASSERT_STREQ("", uio_param->path);
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UIO_DEVICE, param.channel_type);
     ASSERT_STREQ(path, uio_param->path);
 #else
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(-1, rv);
     ASSERT_EQ(ESOCKTNOSUPPORT, errno);
+    ASSERT_EQ(-1, rv);
     errno = 0;
 #endif
 }
@@ -59,15 +59,6 @@ public:
     {
         int rv;
         pirate_init_channel_param(UIO_DEVICE, &param);
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 };
 

--- a/libpirate/test/uio_test.cpp
+++ b/libpirate/test/uio_test.cpp
@@ -57,7 +57,6 @@ class UioTest : public ChannelTest
 public:
     void ChannelInit()
     {
-        int rv;
         pirate_init_channel_param(UIO_DEVICE, &param);
     }
 };

--- a/libpirate/test/unix_socket_test.cpp
+++ b/libpirate/test/unix_socket_test.cpp
@@ -37,17 +37,14 @@ TEST(ChannelUnixSocketTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s", name);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
-    ASSERT_EQ(0, errno);
-    ASSERT_EQ(UNIX_SOCKET, param.channel_type);
-    ASSERT_STREQ("", unix_socket_param->path);
-    ASSERT_EQ(0u, unix_socket_param->iov_len);
-    ASSERT_EQ(0u, unix_socket_param->buffer_size);
+    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(-1, rv);
+    errno = 0;
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s", name, path);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UNIX_SOCKET, param.channel_type);
     ASSERT_STREQ(path, unix_socket_param->path);
     ASSERT_EQ(0u, unix_socket_param->iov_len);
@@ -55,8 +52,8 @@ TEST(ChannelUnixSocketTest, ConfigurationParser) {
 
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u", name, path, iov_len);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UNIX_SOCKET, param.channel_type);
     ASSERT_STREQ(path, unix_socket_param->path);
     ASSERT_EQ(iov_len, unix_socket_param->iov_len);
@@ -65,8 +62,8 @@ TEST(ChannelUnixSocketTest, ConfigurationParser) {
     snprintf(opt, sizeof(opt) - 1, "%s,%s,%u,%u", name, path, iov_len,
             buffer_size);
     rv = pirate_parse_channel_param(opt, &param);
-    ASSERT_EQ(0, rv);
     ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
     ASSERT_EQ(UNIX_SOCKET, param.channel_type);
     ASSERT_STREQ(path, unix_socket_param->path);
     ASSERT_EQ(iov_len, unix_socket_param->iov_len);
@@ -79,20 +76,11 @@ class UnixSocketTest : public ChannelTest,
 public:
     void ChannelInit()
     {
-        int rv;
         pirate_init_channel_param(UNIX_SOCKET, &param);
+        strncpy(param.channel.unix_socket.path, "/tmp/gaps.channel.test.sock", PIRATE_LEN_NAME);
         auto test_param = GetParam();
         param.channel.unix_socket.iov_len = std::get<0>(test_param);
         param.channel.unix_socket.buffer_size = std::get<1>(test_param);
-
-        rv = pirate_set_channel_param(Writer.channel, O_WRONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
-
-        // write and read parameters are the same
-        rv = pirate_set_channel_param(Reader.channel, O_RDONLY, &param);
-        ASSERT_EQ(0, rv);
-        ASSERT_EQ(0, errno);
     }
 
     static const int TEST_BUF_LEN = 32;

--- a/libpirate/udp_shmem.c
+++ b/libpirate/udp_shmem.c
@@ -99,10 +99,7 @@ static inline int is_empty(uint64_t value) {
 static inline int is_full(uint64_t value) { return get_status(value) == 2; }
 
 
-static void udp_shmem_buffer_init_param(int gd, pirate_udp_shmem_param_t *param) {
-    if (strnlen(param->path, 1) == 0) {
-        snprintf(param->path, PIRATE_LEN_NAME - 1, PIRATE_SHMEM_NAME_FMT, gd);
-    }
+static void udp_shmem_buffer_init_param(pirate_udp_shmem_param_t *param) {
     if (param->buffer_size == 0) {
         param->buffer_size = DEFAULT_SMEM_BUF_LEN;
     }
@@ -122,9 +119,11 @@ int udp_shmem_buffer_parse_param(char *str, pirate_udp_shmem_param_t *param) {
         return -1;
     }
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        strncpy(param->path, ptr, sizeof(param->path));
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    strncpy(param->path, ptr, sizeof(param->path));
 
     if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
         param->buffer_size = strtol(ptr, NULL, 10);
@@ -254,12 +253,16 @@ error:
     return NULL;
 }
 
-int udp_shmem_buffer_open(int gd, int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
+int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
 
-    udp_shmem_buffer_init_param(gd, param);
+    udp_shmem_buffer_init_param(param);
+    if (strnlen(param->path, 1) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
     // on successful shm_open (fd > 0) we must shm_unlink before exiting
     // this function
     int fd = shm_open(param->path, O_RDWR | O_CREAT, 0660);
@@ -317,7 +320,7 @@ int udp_shmem_buffer_open(int gd, int flags, pirate_udp_shmem_param_t *param, ud
     }
 
     ctx->flags = flags;
-    return gd;
+    return 0;
 error:
     err = errno;
     ctx->buf = NULL;

--- a/libpirate/udp_shmem.c
+++ b/libpirate/udp_shmem.c
@@ -257,6 +257,7 @@ int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
+    int access = flags & O_ACCMODE;
 
     udp_shmem_buffer_init_param(param);
     if (strnlen(param->path, 1) == 0) {
@@ -277,7 +278,7 @@ int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_
         goto error;
     }
 
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         if (!atomic_compare_exchange_strong(&buf->reader_pid, &init_pid,
                                             (uint64_t)getpid())) {
             errno = EBUSY;
@@ -331,9 +332,10 @@ error:
 
 int udp_shmem_buffer_close(udp_shmem_ctx *ctx) {
   shmem_buffer_t* buf = ctx->buf;
+  int access = ctx->flags & O_ACCMODE;
   const size_t alloc_size = sizeof(shmem_buffer_t) + buf->size;
 
-    if (ctx->flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         atomic_store(&buf->reader_pid, 0);
         pthread_mutex_lock(&buf->mutex);
         pthread_cond_signal(&buf->is_not_full);

--- a/libpirate/udp_shmem.h
+++ b/libpirate/udp_shmem.h
@@ -19,7 +19,7 @@
 #include "udp_shmem_interface.h"
 
 int udp_shmem_buffer_parse_param(char *str, pirate_udp_shmem_param_t *param);
-int udp_shmem_buffer_open(int gd, int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
+int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
 int udp_shmem_buffer_close(udp_shmem_ctx *ctx);
 ssize_t udp_shmem_buffer_read(const pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx, void *buf,
                             size_t count);

--- a/libpirate/udp_shmem_interface.c
+++ b/libpirate/udp_shmem_interface.c
@@ -28,11 +28,11 @@ int pirate_udp_shmem_parse_param(char *str, pirate_udp_shmem_param_t *param) {
 #endif
 }
 
-int pirate_udp_shmem_open(int gd, int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
+int pirate_udp_shmem_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
 #ifdef PIRATE_SHMEM_FEATURE
-    return udp_shmem_buffer_open(gd, flags, param, ctx);
+    return udp_shmem_buffer_open(flags, param, ctx);
 #else
-    (void) gd, (void) flags, (void) param, (void) ctx;
+    (void) flags, (void) param, (void) ctx;
     return -1;
 #endif
 }

--- a/libpirate/udp_shmem_interface.h
+++ b/libpirate/udp_shmem_interface.h
@@ -25,7 +25,7 @@ typedef struct {
 } udp_shmem_ctx;
 
 int pirate_udp_shmem_parse_param(char *str, pirate_udp_shmem_param_t *param);
-int pirate_udp_shmem_open(int gd, int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
+int pirate_udp_shmem_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
 int pirate_udp_shmem_close(udp_shmem_ctx *ctx);
 ssize_t pirate_udp_shmem_read(const pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_udp_shmem_write(const pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -24,12 +24,9 @@
 #include "pirate_common.h"
 #include "udp_socket.h"
 
-static void pirate_udp_socket_init_param(int gd, pirate_udp_socket_param_t *param) {
+static void pirate_udp_socket_init_param(pirate_udp_socket_param_t *param) {
     if (strnlen(param->addr, 1) == 0) {
         snprintf(param->addr, sizeof(param->addr) - 1, DEFAULT_UDP_IP_ADDR);
-    }
-    if (param->port == 0) {
-        param->port = PIRATE_UDP_PORT_BASE + gd;
     }
 }
 
@@ -41,13 +38,17 @@ int pirate_udp_socket_parse_param(char *str, pirate_udp_socket_param_t *param) {
         return -1;
     }
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        strncpy(param->addr, ptr, sizeof(param->addr));
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    strncpy(param->addr, ptr, sizeof(param->addr));
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        param->port = strtol(ptr, NULL, 10);
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    param->port = strtol(ptr, NULL, 10);
 
     if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
         param->iov_len = strtol(ptr, NULL, 10);
@@ -147,16 +148,20 @@ static int udp_socket_writer_open(pirate_udp_socket_param_t *param, udp_socket_c
     return 0;
 }
 
-int pirate_udp_socket_open(int gd, int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
+int pirate_udp_socket_open(int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
     int rv = -1;
-    pirate_udp_socket_init_param(gd, param);
+    pirate_udp_socket_init_param(param);
+    if (param->port <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
     if (flags == O_RDONLY) {
         rv = udp_socket_reader_open(param, ctx);
     } else if (flags == O_WRONLY) {
         rv = udp_socket_writer_open(param, ctx);
     }
 
-    return rv == 0 ? gd : rv;
+    return rv;
 }
 
 int pirate_udp_socket_close(udp_socket_ctx *ctx) {

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -150,14 +150,16 @@ static int udp_socket_writer_open(pirate_udp_socket_param_t *param, udp_socket_c
 
 int pirate_udp_socket_open(int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
+
     pirate_udp_socket_init_param(param);
     if (param->port <= 0) {
         errno = EINVAL;
         return -1;
     }
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = udp_socket_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else {
         rv = udp_socket_writer_open(param, ctx);
     }
 

--- a/libpirate/udp_socket.h
+++ b/libpirate/udp_socket.h
@@ -23,7 +23,7 @@ typedef struct {
 } udp_socket_ctx;
 
 int pirate_udp_socket_parse_param(char *str, pirate_udp_socket_param_t *param);
-int pirate_udp_socket_open(int gd, int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx);
+int pirate_udp_socket_open(int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx);
 int pirate_udp_socket_close(udp_socket_ctx *ctx);
 ssize_t pirate_udp_socket_read(const pirate_udp_socket_param_t *param, udp_socket_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_udp_socket_write(const pirate_udp_socket_param_t *param, udp_socket_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/uio.c
+++ b/libpirate/uio.c
@@ -85,9 +85,9 @@ int pirate_internal_uio_parse_param(char *str, pirate_uio_param_t *param) {
     return 0;
 }
 
-static shmem_buffer_t *uio_buffer_init(int gd, int fd) {
+static shmem_buffer_t *uio_buffer_init(unsigned short region, int fd) {
     shmem_buffer_t *uio_buffer = mmap(NULL, buffer_size(),
-        PROT_READ | PROT_WRITE, MAP_SHARED, fd, gd * getpagesize());
+        PROT_READ | PROT_WRITE, MAP_SHARED, fd, region * getpagesize());
 
     if (uio_buffer == MAP_FAILED) {
         return NULL;
@@ -98,7 +98,7 @@ static shmem_buffer_t *uio_buffer_init(int gd, int fd) {
     return uio_buffer;
 }
 
-int pirate_internal_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
+int pirate_internal_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
@@ -110,7 +110,7 @@ int pirate_internal_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_c
         return -1;
     }
 
-    buf = uio_buffer_init(gd, ctx->fd);
+    buf = uio_buffer_init(param->region, ctx->fd);
     ctx->buf = buf;
     if (ctx->buf == NULL) {
         goto error;
@@ -139,7 +139,7 @@ int pirate_internal_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_c
     }
 
     ctx->flags = flags;
-    return gd;
+    return 0;
 error:
     err = errno;
     close(ctx->fd);

--- a/libpirate/uio.h
+++ b/libpirate/uio.h
@@ -19,7 +19,7 @@
 #include "uio_interface.h"
 
 int pirate_internal_uio_parse_param(char *str, pirate_uio_param_t *param);
-int pirate_internal_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx);
+int pirate_internal_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx);
 int pirate_internal_uio_close(uio_ctx *ctx);
 ssize_t pirate_internal_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_internal_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/uio_interface.c
+++ b/libpirate/uio_interface.c
@@ -28,11 +28,11 @@ int pirate_uio_parse_param(char *str, pirate_uio_param_t *param) {
 #endif
 }
 
-int pirate_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
+int pirate_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
 #ifdef PIRATE_SHMEM_FEATURE
-    return pirate_internal_uio_open(gd, flags, param, ctx);
+    return pirate_internal_uio_open(flags, param, ctx);
 #else
-    (void) gd, (void) flags, (void) param, (void) ctx;
+    (void) flags, (void) param, (void) ctx;
     errno = ESOCKTNOSUPPORT;
     return -1;
 #endif

--- a/libpirate/uio_interface.h
+++ b/libpirate/uio_interface.h
@@ -26,7 +26,7 @@ typedef struct {
 } uio_ctx;
 
 int pirate_uio_parse_param(char *str, pirate_uio_param_t *param);
-int pirate_uio_open(int gd, int flags, pirate_uio_param_t *param, uio_ctx *ctx);
+int pirate_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx);
 int pirate_uio_close(uio_ctx *ctx);
 ssize_t pirate_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/unix_socket.c
+++ b/libpirate/unix_socket.c
@@ -159,14 +159,15 @@ static int unix_socket_writer_open(pirate_unix_socket_param_t *param, unix_socke
 
 int pirate_unix_socket_open(int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
 
     if (strnlen(param->path, 1) == 0) {
         errno = EINVAL;
         return -1;
     }
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = unix_socket_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else {
         rv = unix_socket_writer_open(param, ctx);
     }
 

--- a/libpirate/unix_socket.c
+++ b/libpirate/unix_socket.c
@@ -25,12 +25,6 @@
 #include "pirate_common.h"
 #include "unix_socket.h"
 
-static void pirate_unix_socket_init_param(int gd, pirate_unix_socket_param_t *param) {
-    if (strnlen(param->path, 1) == 0) {
-        snprintf(param->path, PIRATE_LEN_NAME - 1, PIRATE_UNIX_SOCKET_NAME_FMT, gd);
-    }
-}
-
 int pirate_unix_socket_parse_param(char *str, pirate_unix_socket_param_t *param) {
     char *ptr = NULL;
 
@@ -39,9 +33,11 @@ int pirate_unix_socket_parse_param(char *str, pirate_unix_socket_param_t *param)
         return -1;
     }
 
-    if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
-        strncpy(param->path, ptr, sizeof(param->path));
+    if ((ptr = strtok(NULL, OPT_DELIM)) == NULL) {
+        errno = EINVAL;
+        return -1;
     }
+    strncpy(param->path, ptr, sizeof(param->path));
 
     if ((ptr = strtok(NULL, OPT_DELIM)) != NULL) {
         param->iov_len = strtol(ptr, NULL, 10);
@@ -161,17 +157,20 @@ static int unix_socket_writer_open(pirate_unix_socket_param_t *param, unix_socke
     return -1;
 }
 
-int pirate_unix_socket_open(int gd, int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx) {
+int pirate_unix_socket_open(int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx) {
     int rv = -1;
 
-    pirate_unix_socket_init_param(gd, param);
+    if (strnlen(param->path, 1) == 0) {
+        errno = EINVAL;
+        return -1;
+    }
     if (flags == O_RDONLY) {
         rv = unix_socket_reader_open(param, ctx);
     } else if (flags == O_WRONLY) {
         rv = unix_socket_writer_open(param, ctx);
     }
 
-    return rv == 0 ? gd : rv;
+    return rv;
 }
 
 

--- a/libpirate/unix_socket.h
+++ b/libpirate/unix_socket.h
@@ -23,7 +23,7 @@ typedef struct {
 } unix_socket_ctx;
 
 int pirate_unix_socket_parse_param(char *str, pirate_unix_socket_param_t *param);
-int pirate_unix_socket_open(int gd, int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx);
+int pirate_unix_socket_open(int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx);
 int pirate_unix_socket_close(unix_socket_ctx *ctx);
 ssize_t pirate_unix_socket_read(const pirate_unix_socket_param_t *param, unix_socket_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_unix_socket_write(const pirate_unix_socket_param_t *param, unix_socket_ctx *ctx, const void *buf, size_t count);


### PR DESCRIPTION
* Change the API of `pirate_open()` to accept the pirate_channel_param_t as an argument instead of the gaps descriptor. Do not pass the gaps descriptor as an input argument. Return the gaps descriptor as the return value.
* Modifies the `pirate_pipe()` function to behave more like the `pipe()` system call.
* Remove the flags argument from `pirate_close()`.