### PR TITLE
libpirate cleanup

### DIFF
--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -216,6 +216,7 @@ static int ge_eth_writer_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
 
 int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
 
     pirate_ge_eth_init_param(param);
     if (param->port <= 0) {
@@ -227,9 +228,9 @@ int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx)
         return -1;
     }
 
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = ge_eth_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else if (access == O_WRONLY) {
         rv = ge_eth_writer_open(param, ctx);
     }
 

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -318,11 +318,19 @@ int pirate_open_param(pirate_channel_param_t *param, int flags);
 // The caller is responsible for closing the reader and the writer.
 //
 // On success, zero is returned. On error, -1 is returned,
-// and errno is set appropriately.
+// and errno is set appropriately. If the channel type
+// does not support this functionality then errno is set
+// to ENOSYS.
 //
 // The argument flags must be O_RDWR.
 
 int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
+
+// Returns 1 if the channel type supports the
+// pirate_pipe_param() and pirate_pipe_parse()
+// functions. Otherwise return 0.
+
+int pirate_pipe_channel_type(channel_enum_t channel_type);
 
 // pirate_read() attempts to read up to count bytes from
 // gaps descriptor gd into the buffer starting at buf.

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -295,7 +295,7 @@ int pirate_get_channel_param(int gd, pirate_channel_param_t *param);
 // The return value is the input gaps descriptor, or -1 if an
 // error occurred (in which case, errno is set appropriately).
 //
-// The argument flags must be O_RDONLY or O_WRONLY.
+// The argument flags must have access mode O_RDONLY or O_WRONLY.
 
 int pirate_open_parse(const char *param, int flags);
 
@@ -307,7 +307,7 @@ int pirate_open_parse(const char *param, int flags);
 // The return value is a unique gaps descriptor, or -1 if an
 // error occurred (in which case, errno is set appropriately).
 //
-// The argument flags must be O_RDONLY or O_WRONLY.
+// The argument flags must have access mode O_RDONLY or O_WRONLY.
 
 int pirate_open_param(pirate_channel_param_t *param, int flags);
 
@@ -328,7 +328,7 @@ int pirate_pipe_channel_type(channel_enum_t channel_type);
 // does not support this functionality then errno is set
 // to ENOSYS.
 //
-// The argument flags must be O_RDWR.
+// The argument flags must have access mode O_RDWR.
 
 int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 
@@ -343,7 +343,7 @@ int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 // does not support this functionality then errno is set
 // to ENOSYS.
 //
-// The argument flags must be O_RDWR.
+// The argument flags must have access mode O_RDWR.
 
 int pirate_pipe_parse(int gd[2], const char *param, int flags);
 

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -311,8 +311,14 @@ int pirate_open_parse(const char *param, int flags);
 
 int pirate_open_param(pirate_channel_param_t *param, int flags);
 
+// Returns 1 if the channel type supports the
+// pirate_pipe_param() and pirate_pipe_parse()
+// functions. Otherwise return 0.
+
+int pirate_pipe_channel_type(channel_enum_t channel_type);
+
 // Opens both ends of the gaps channel specified by the
-// gaps descriptor. See pipe() system call. Some channel
+// parameter value. See pipe() system call. Some channel
 // types cannot be opened for both reading and writing.
 //
 // The caller is responsible for closing the reader and the writer.
@@ -326,11 +332,20 @@ int pirate_open_param(pirate_channel_param_t *param, int flags);
 
 int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 
-// Returns 1 if the channel type supports the
-// pirate_pipe_param() and pirate_pipe_parse()
-// functions. Otherwise return 0.
+// Opens both ends of the gaps channel specified by the
+// parameter string. See pipe() system call. Some channel
+// types cannot be opened for both reading and writing.
+//
+// The caller is responsible for closing the reader and the writer.
+//
+// On success, zero is returned. On error, -1 is returned,
+// and errno is set appropriately. If the channel type
+// does not support this functionality then errno is set
+// to ENOSYS.
+//
+// The argument flags must be O_RDWR.
 
-int pirate_pipe_channel_type(channel_enum_t channel_type);
+int pirate_pipe_parse(int gd[2], const char *param, int flags);
 
 // pirate_read() attempts to read up to count bytes from
 // gaps descriptor gd into the buffer starting at buf.

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -292,7 +292,8 @@ int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *c
     ssize_t sz;
     int fd_root = -1;
     ctx->flags = flags;
-    const mode_t mode = ctx->flags == O_RDONLY ? S_IRUSR : S_IWUSR;
+    int access = ctx->flags & O_ACCMODE;
+    const mode_t mode = access == O_RDONLY ? S_IRUSR : S_IWUSR;
 
     /* Open the root device to configure and establish a session */
     pirate_mercury_init_param(param);
@@ -359,10 +360,10 @@ int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *c
         }
 
         snprintf(ctx->path, PIRATE_LEN_NAME - 1, PIRATE_MERCURY_DEFAULT_FMT,
-                    param->session.id, flags == O_RDONLY ? "read" : "write");
+                    param->session.id, access == O_RDONLY ? "read" : "write");
     } else {
         snprintf(ctx->path, PIRATE_LEN_NAME - 1, PIRATE_MERCURY_SESSION_FMT,
-                    param->session.id, flags == O_RDONLY ? "read" : "write");
+                    param->session.id, access == O_RDONLY ? "read" : "write");
     }
 
     /* Open the device */

--- a/libpirate/pipe.c
+++ b/libpirate/pipe.c
@@ -68,6 +68,21 @@ int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx) {
     return 0;
 }
 
+int pirate_pipe_pipe(int flags, pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx) {
+    (void) flags;
+    (void) param;
+    int rv, fd[2];
+
+    rv = pipe(fd);
+    if (rv < 0) {
+        return rv;
+    }
+
+    read_ctx->fd = fd[0];
+    write_ctx->fd = fd[1];
+    return 0;
+}
+
 int pirate_pipe_close(pipe_ctx *ctx) {
     int rv = -1;
 

--- a/libpirate/pipe.h
+++ b/libpirate/pipe.h
@@ -24,6 +24,7 @@ typedef struct {
  } pipe_ctx;
 
 int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param);
+int pirate_pipe_pipe(int flags, pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx);
 int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx);
 int pirate_pipe_close(pipe_ctx *ctx);
 ssize_t pirate_pipe_read(const pirate_pipe_param_t *param, pipe_ctx *ctx, void *buf, size_t count);

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -323,6 +323,15 @@ int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags) {
     return 0;
 }
 
+int pirate_pipe_parse(int gd[2], const char *param, int flags) {
+    pirate_channel_param_t vals;
+
+    if (pirate_parse_channel_param(param, &vals) < 0) {
+        return -1;
+    }
+
+    return pirate_pipe_param(gd, &vals, flags);
+}
 
 int pirate_close(int gd) {
     pirate_channel_t *channel;

--- a/libpirate/tcp_socket.c
+++ b/libpirate/tcp_socket.c
@@ -181,15 +181,16 @@ static int tcp_socket_writer_open(pirate_tcp_socket_param_t *param, tcp_socket_c
 
 int pirate_tcp_socket_open(int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
 
     pirate_tcp_socket_init_param(param);
     if (param->port <= 0) {
         errno = EINVAL;
         return -1;
     }
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = tcp_socket_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else {
         rv = tcp_socket_writer_open(param, ctx);
     }
 

--- a/libpirate/test/channel_test.cpp
+++ b/libpirate/test/channel_test.cpp
@@ -104,7 +104,9 @@ void ChannelTest::ReaderChannelClose()
 void ChannelTest::Run()
 {
     RunChildOpen(true);
-    RunChildOpen(false);
+    if (pirate_pipe_channel_type(param.channel_type)) {
+        RunChildOpen(false);
+    }
 }
 
 void ChannelTest::RunChildOpen(bool child)

--- a/libpirate/udp_shmem.c
+++ b/libpirate/udp_shmem.c
@@ -257,6 +257,7 @@ int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
+    int access = flags & O_ACCMODE;
 
     udp_shmem_buffer_init_param(param);
     if (strnlen(param->path, 1) == 0) {
@@ -277,7 +278,7 @@ int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_
         goto error;
     }
 
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         if (!atomic_compare_exchange_strong(&buf->reader_pid, &init_pid,
                                             (uint64_t)getpid())) {
             errno = EBUSY;
@@ -331,9 +332,10 @@ error:
 
 int udp_shmem_buffer_close(udp_shmem_ctx *ctx) {
   shmem_buffer_t* buf = ctx->buf;
+  int access = ctx->flags & O_ACCMODE;
   const size_t alloc_size = sizeof(shmem_buffer_t) + buf->size;
 
-    if (ctx->flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         atomic_store(&buf->reader_pid, 0);
         pthread_mutex_lock(&buf->mutex);
         pthread_cond_signal(&buf->is_not_full);

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -150,14 +150,16 @@ static int udp_socket_writer_open(pirate_udp_socket_param_t *param, udp_socket_c
 
 int pirate_udp_socket_open(int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
+
     pirate_udp_socket_init_param(param);
     if (param->port <= 0) {
         errno = EINVAL;
         return -1;
     }
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = udp_socket_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else {
         rv = udp_socket_writer_open(param, ctx);
     }
 

--- a/libpirate/unix_socket.c
+++ b/libpirate/unix_socket.c
@@ -159,14 +159,15 @@ static int unix_socket_writer_open(pirate_unix_socket_param_t *param, unix_socke
 
 int pirate_unix_socket_open(int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx) {
     int rv = -1;
+    int access = flags & O_ACCMODE;
 
     if (strnlen(param->path, 1) == 0) {
         errno = EINVAL;
         return -1;
     }
-    if (flags == O_RDONLY) {
+    if (access == O_RDONLY) {
         rv = unix_socket_reader_open(param, ctx);
-    } else if (flags == O_WRONLY) {
+    } else {
         rv = unix_socket_writer_open(param, ctx);
     }
 


### PR DESCRIPTION
* Do not pthread_fork() to implement pirate_pipe_open(). Only support pirate_pipe_open() for a limited number of channel types that can be opened without spawning threads.
* Implement pirate_pipe_parse()
* Cleanup access mode usage. Preserve the remaining bits of the flags parameter.