### PR TITLE
Switch to use separate demos cmake files.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,20 @@ name: CI
 on: [push]
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build documentation
+      run: |
+        pip3 install sphinx
+        export PATH="$HOME/.local/bin:$PATH"
+        sphinx-build -M html doc build/doc
+    - name: Make artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: doc
+        path: build/doc
   build:
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +54,6 @@ jobs:
       with:
         name: libpirate
         path: dist/libpirate
-      if: github.ref == 'refs/heads/master'
     - name: libpirate tests
       timeout-minutes: 5
       run: |
@@ -56,31 +69,6 @@ jobs:
       run: |
         cd build/demos/time_demo/test
         ./ts_test.sh
-    - name: Build documentation
-      run: |
-        pip3 install sphinx
-        export PATH="$HOME/.local/bin:$PATH"
-        sphinx-build -M html doc images/ubuntu/doc
-    - name: Build pirateteam/ubuntu
-      run: |
-        cp -a dist images/ubuntu
-        cp -a libpirate images/ubuntu
-        cp -a demos images/ubuntu
-        cp -a CMakeLists.txt images/ubuntu
-        docker build -t pirateteam/ubuntu images/ubuntu
-        docker save pirateteam/ubuntu | gzip > ubuntu-latest.tar.gz
-      if: github.ref == 'refs/heads/master'
-    - name: Make pirateteam/ubuntu artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: ubuntu-latest
-        path: ubuntu-latest.tar.gz
-      if: github.ref == 'refs/heads/master'
-    - name: Post docker images
-      run: |
-        echo ${{ secrets.docker_password }} | docker login -u gapspirateteam --password-stdin
-        docker push pirateteam/ubuntu
-      if: github.ref == 'refs/heads/master'
   shmem:
     runs-on: ubuntu-latest
     steps:
@@ -189,4 +177,45 @@ jobs:
       with:
         name: pnt_demo
         path: build_pnt_demo/pnt_demo
+      if: github.ref == 'refs/heads/master'
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [docs, build]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Get documentation
+      uses: actions/download-artifact@v1
+      with:
+        name: doc
+        path: images/ubuntu/doc
+    - name: Get library
+      uses: actions/download-artifact@v1
+      with:
+        name: libpirate
+        path: images/ubuntu/libpirate
+    - name: Build pirateteam/ubuntu
+      run: |
+        cp -a demos images/ubuntu
+        docker build -t pirateteam/ubuntu images/ubuntu
+        docker save pirateteam/ubuntu | gzip > ubuntu-latest.tar.gz
+    - name: Make pirateteam/ubuntu artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: ubuntu-latest
+        path: ubuntu-latest.tar.gz
+    - name: Build demos on pirateteam/ubuntu
+      run: |
+        mkdir -p build
+        docker run --mount type=bind,src=`pwd`/build,dst=/root/build \
+                   -w /root/build \
+                   pirateteam/ubuntu \
+                   cmake ../pirate/demos
+        docker run --mount type=bind,src=`pwd`/build,dst=/root/build \
+                   -w /root/build \
+                   pirateteam/ubuntu \
+                   make
+    - name: Post docker images
+      run: |
+        echo ${{ secrets.docker_password }} | docker login -u gapspirateteam --password-stdin
+        docker push pirateteam/ubuntu
       if: github.ref == 'refs/heads/master'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,31 +47,6 @@ if (HAVE_STD_ATOMIC)
 endif(HAVE_STD_ATOMIC)
 
 add_subdirectory(libpirate)
-
-if (CHANNEL_DEMO)
-    include_directories(${CMAKE_SOURCE_DIR}/libpirate)
-    link_directories(${CMAKE_BINARY_DIR}/libpirate)
-    add_subdirectory(demos/channel_demo)
-endif(CHANNEL_DEMO)
-
-if (PNT_DEMO)
-    include_directories(${CMAKE_SOURCE_DIR}/libpirate)
-    link_directories(${CMAKE_BINARY_DIR}/libpirate)
-    add_subdirectory(demos/pnt_demo/4.pirate)
-endif(PNT_DEMO)
-
-if (GAPS_DEMOS)
-    include_directories(${CMAKE_SOURCE_DIR}/libpirate)
-    link_directories(${CMAKE_BINARY_DIR}/libpirate)
-
-    add_subdirectory(demos/simple_demo)
-    add_subdirectory(demos/time_demo)
-    add_subdirectory(demos/channel_demo)
-    add_subdirectory(demos/cxx_demo)
-    add_subdirectory(demos/pnt_demo/4.pirate)
-
-    if (NOT GAPS_DISABLE)
-        add_subdirectory(demos/enclave_demo)
-    endif(NOT GAPS_DISABLE)
-
-endif(GAPS_DEMOS)
+include_directories(BEFORE libpirate)
+link_directories(BEFORE ${CMAKE_BINARY_DIR}/libpirate)
+add_subdirectory(demos)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -35,10 +35,10 @@ set(PIRATE_C_FLAGS -Werror -Wall -Wextra -Wpedantic -fPIC)
 
 set(PIRATE_STATIC_LIB libpirate_static)
 set(PIRATE_SHARED_LIB libpirate_shared)
-set(PIRATE_APP_LIBS pirate pthread)
+set(PIRATE_APP_LIBS pirate)
 
 if (PIRATE_SHMEM_FEATURE)
-    set(PIRATE_APP_LIBS ${PIRATE_APP_LIBS} rt)
+    set(PIRATE_APP_LIBS ${PIRATE_APP_LIBS} pthread rt)
 endif(PIRATE_SHMEM_FEATURE)
 
 if (GAPS_DEMOS)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-include(CheckIncludeFile)
 
 project(pirate_demos)
 
@@ -17,11 +16,6 @@ if(BUILD_ALL)
     SET(GAPS_DEMOS ON BOOL)
     SET(GAPS_BENCH ON BOOL)
 endif(BUILD_ALL)
-
-CHECK_INCLUDE_FILE(stdatomic.h HAVE_STD_ATOMIC)
-if (HAVE_STD_ATOMIC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_STD_ATOMIC")
-endif(HAVE_STD_ATOMIC)
 
 if (NOT GAPS_DISABLE)
   # Use lld for demos if a linker is not already set.

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.13)
+include(CheckIncludeFile)
+
+project(pirate_demos)
+
+# Common options
+option(GAPS_DISABLE "Disable compilation with GAPS annotations" OFF)
+option(GAPS_DEMOS "Enable compilation of all GAPS demo applications" ON)
+option(CHANNEL_DEMO "Enable compilation of GAPS channel application" OFF)
+option(PIRATE_SHMEM_FEATURE "support shared memory channels" OFF)
+option(PNT_DEMO "Enable compilation of pnt application" OFF)
+option(BUILD_ALL "Enable PIRATE_SHMEM_FEATURE, PIRATE_UNIT_TEST, GAPS_DEMOS, and GAPS_BENCH" OFF)
+
+if(BUILD_ALL)
+    SET(PIRATE_SHMEM_FEATURE ON BOOL)
+    SET(PIRATE_UNIT_TEST ON BOOL)
+    SET(GAPS_DEMOS ON BOOL)
+    SET(GAPS_BENCH ON BOOL)
+endif(BUILD_ALL)
+
+CHECK_INCLUDE_FILE(stdatomic.h HAVE_STD_ATOMIC)
+if (HAVE_STD_ATOMIC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_STD_ATOMIC")
+endif(HAVE_STD_ATOMIC)
+
+if (NOT GAPS_DISABLE)
+  # Use lld for demos if a linker is not already set.
+  if (CMAKE_EXE_LINKER_FLAGS)
+    string(FIND ${CMAKE_EXE_LINKER_FLAGS} -fuse-ld USE_LD_IDX)
+  else()
+    set(USE_LD_IDX -1)
+  endif()
+
+  if (USE_LD_IDX EQUAL -1)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+  endif()
+endif()
+
+# Common build options
+set(PIRATE_C_FLAGS -Werror -Wall -Wextra -Wpedantic -fPIC)
+
+set(PIRATE_STATIC_LIB libpirate_static)
+set(PIRATE_SHARED_LIB libpirate_shared)
+set(PIRATE_APP_LIBS pirate pthread)
+
+if (PIRATE_SHMEM_FEATURE)
+    set(PIRATE_APP_LIBS ${PIRATE_APP_LIBS} rt)
+endif(PIRATE_SHMEM_FEATURE)
+
+if (GAPS_DEMOS)
+    add_subdirectory(simple_demo)
+    add_subdirectory(time_demo)
+    add_subdirectory(channel_demo)
+    add_subdirectory(cxx_demo)
+    add_subdirectory(pnt_demo/4.pirate)
+endif(GAPS_DEMOS)
+
+if (CHANNEL_DEMO)
+    add_subdirectory(channel_demo)
+endif(CHANNEL_DEMO)
+
+if (NOT GAPS_DISABLE)
+   add_subdirectory(enclave_demo)
+endif(NOT GAPS_DISABLE)
+
+if (PNT_DEMO)
+    add_subdirectory(pnt_demo/4.pirate)
+endif(PNT_DEMO)

--- a/images/ubuntu/Dockerfile
+++ b/images/ubuntu/Dockerfile
@@ -3,9 +3,7 @@ MAINTAINER Joe Hendrix (jhendrix@galois.com)
 RUN apt-get update \
  && apt-get install --no-install-recommends -y libjpeg-dev libssl-dev libx11-dev \
  && rm -rf /var/lib/apt/lists/*
-COPY dist/libpirate /usr/local
+COPY libpirate /usr/local
 COPY doc   /root/pirate/doc
-COPY libpirate /root/pirate/libpirate
 COPY demos /root/pirate/demos
-COPY CMakeLists.txt /root/pirate/CMakeLists.txt
 WORKDIR /root

--- a/libpirate/CMakeLists.txt
+++ b/libpirate/CMakeLists.txt
@@ -43,6 +43,9 @@ install(TARGETS ${PIRATE_SHARED_LIB} DESTINATION lib)
 install(TARGETS ${PIRATE_STATIC_LIB} DESTINATION lib)
 
 if(GAPS_BENCH)
+    include_directories(BEFORE libpirate)
+    link_directories(BEFORE ${CMAKE_BINARY_DIR}/libpirate)
+
     add_executable(primitives_bench_thr ${PIRATE_SOURCES} bench/primitives_bench_thr.c)
     add_executable(primitives_bench_thr_vector ${PIRATE_SOURCES} bench/primitives_bench_thr_vector.c)
     add_executable(primitives_bench_lat ${PIRATE_SOURCES} bench/primitives_bench_lat.c)
@@ -73,6 +76,9 @@ endif(GAPS_BENCH)
 if(PIRATE_UNIT_TEST)
     find_package(GTest REQUIRED)
     include_directories(${GTEST_INCLUDE_DIR})
+
+    include_directories(BEFORE libpirate)
+    link_directories(BEFORE ${CMAKE_BINARY_DIR}/libpirate)
 
     set(PIRATE_C_TEST_FLAGS ${PIRATE_C_FLAGS})
     set(GAPS_CHANNELS_TEST_LIBS ${PIRATE_APP_LIBS} pthread)


### PR DESCRIPTION
This is intended to make the docker image demo build process self-contained.

It allows the demos to be configured and build independently of libpirate while still supporting an integrated scenario at the cost of some duplication.

It also updates the docker image build process to be in a separate task, and to test that the demos can be built prior to upload.