### PR TITLE
Replace semaphore and sleep with pthread barrier

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -47,15 +47,14 @@ if (GAPS_DEMOS)
     add_subdirectory(channel_demo)
     add_subdirectory(cxx_demo)
     add_subdirectory(pnt_demo/4.pirate)
+    if (NOT GAPS_DISABLE)
+        add_subdirectory(enclave_demo)
+    endif(NOT GAPS_DISABLE)
 endif(GAPS_DEMOS)
 
 if (CHANNEL_DEMO)
     add_subdirectory(channel_demo)
 endif(CHANNEL_DEMO)
-
-if (NOT GAPS_DISABLE)
-   add_subdirectory(enclave_demo)
-endif(NOT GAPS_DISABLE)
 
 if (PNT_DEMO)
     add_subdirectory(pnt_demo/4.pirate)

--- a/libpirate/test/channel_test.hpp
+++ b/libpirate/test/channel_test.hpp
@@ -61,13 +61,10 @@ protected:
     static const ssize_t DEFAULT_STEP_LEN = 1;
 
     // Reader writer synchronization
-    sem_t sem;
+    pthread_barrier_t barrier;
 
     // Channel parameters
     pirate_channel_param_t param;
-
-    // Optional inter-write delay
-    uint32_t WriteDelayUs;
 
     // If true the producer and consumer
     // open the channel.

--- a/libpirate/test/ge_eth_test.cpp
+++ b/libpirate/test/ge_eth_test.cpp
@@ -79,10 +79,6 @@ class GeEthTest : public ChannelTest, public WithParamInterface<unsigned>
 public:
     void ChannelInit()
     {
-        // Since UDP is unreliable it's possible to get out of sync.
-        // Use write delay to reduce the chance of that
-        WriteDelayUs = 1000;
-
         pirate_init_channel_param(GE_ETH, &param);
         param.channel.ge_eth.port = 0x4745;
         param.channel.ge_eth.message_id = 0x5F475243;

--- a/libpirate/test/mercury_test.cpp
+++ b/libpirate/test/mercury_test.cpp
@@ -197,8 +197,6 @@ class MercuryTest : public ChannelTest, public WithParamInterface<MercuryTestPar
 public:
     void ChannelInit() override
     {
-        WriteDelayUs = 10000;
-
         mMercuryParam = GetParam();
         Writer.channel = Reader.channel = mMercuryParam.channel;
 

--- a/libpirate/test/mercury_test.cpp
+++ b/libpirate/test/mercury_test.cpp
@@ -230,6 +230,9 @@ public:
         rv = mercury_cmd_stat_clear(rdParam.channel.mercury.session.id);
         ASSERT_EQ(0, rv);
         ASSERT_EQ(0, errno);
+
+        int sts = pthread_barrier_wait(&barrier);
+        ASSERT_TRUE(sts == 0 || sts == PTHREAD_BARRIER_SERIAL_THREAD);
     }
 
     void ReaderChannelOpen() override
@@ -250,6 +253,9 @@ public:
         rv = mercury_cmd_stat_clear(rdParam.channel.mercury.session.id);
         ASSERT_EQ(0, rv);
         ASSERT_EQ(0, errno);
+
+        int sts = pthread_barrier_wait(&barrier);
+        ASSERT_TRUE(sts == 0 || sts == PTHREAD_BARRIER_SERIAL_THREAD);
     }
 
     void WriterChannelClose() override {

--- a/libpirate/test/udp_socket_test.cpp
+++ b/libpirate/test/udp_socket_test.cpp
@@ -86,10 +86,6 @@ class UdpSocketTest : public ChannelTest,
 public:
     void ChannelInit()
     {
-        // Since UDP is unreliable it's possible to get out of sync.
-        // Use write delay to reduce the chance of that
-        WriteDelayUs = 1000;
-
         pirate_init_channel_param(UDP_SOCKET, &param);
         param.channel.udp_socket.port = 26427;
         auto test_param = GetParam();


### PR DESCRIPTION
Use a barrier to ensure that the reader and writer threads have opened the channel. Use the barrier to ensure that each round of reading/writing has completed.