### PR TITLE
Add libpirate API to unparse a pirate_channel_param_t

### DIFF
--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -265,7 +265,7 @@ int pirate_parse_channel_param(const char *str, pirate_channel_param_t *param);
 //
 // Parameters
 //  gd           - GAPS channel number
-//  desc         - string to contain channel description
+//  str          - string to contain channel description
 //  len          - max len allowed in desc
 //
 // Upon successful return, this function returns the
@@ -313,17 +313,7 @@ int pirate_get_channel_param(int gd, pirate_channel_param_t *param);
 //
 // Parameters
 //  gd           - GAPS channel number
-//  desc         - string to contain channel description
-//  len          - max len allowed in desc
-//
-// Return:
-//  length of the channel description string
-// -1 on failure, errno is set
-// Get channel parameters as a string
-//
-// Parameters
-//  gd           - GAPS channel number
-//  desc         - string to contain channel description
+//  str          - string to contain channel description
 //  len          - max len allowed in desc
 //
 // Upon successful return, this function returns the

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -246,6 +246,7 @@ typedef struct {
 // Parameters:
 //  channel_type - GAPS channel type
 //  param        - channel parameters to be initialized
+
 void pirate_init_channel_param(channel_enum_t channel_type, pirate_channel_param_t *param);
 
 // Parse a string with gaps channel configuration options.
@@ -257,7 +258,29 @@ void pirate_init_channel_param(channel_enum_t channel_type, pirate_channel_param
 // Return:
 //  0 on success
 // -1 on failure
+
 int pirate_parse_channel_param(const char *str, pirate_channel_param_t *param);
+
+// Get channel parameters as a string
+//
+// Parameters
+//  gd           - GAPS channel number
+//  desc         - string to contain channel description
+//  len          - max len allowed in desc
+//
+// Upon successful return, this function returns the
+// number of characters printed (excluding the null byte
+// used to end output to strings). The function does not
+// write more than len bytes (including the terminating null
+// byte ('\0')). If the output was truncated due to this
+//  limit, then the return value is the number of characters
+// (excluding the terminating null byte) which would have been
+// written to the final string if enough space had been
+// available. Thus, a return value of len or more means that
+// the output was truncated. If an output error is encountered,
+// a negative value is returned.
+
+int pirate_unparse_channel_param(const pirate_channel_param_t *param, char *str, int len);
 
 #define OPT_DELIM ","
 #define GAPS_CHANNEL_OPTIONS                                                     \
@@ -296,14 +319,33 @@ int pirate_get_channel_param(int gd, pirate_channel_param_t *param);
 // Return:
 //  length of the channel description string
 // -1 on failure, errno is set
-int pirate_get_channel_description(int gd, char *desc, int len);
+// Get channel parameters as a string
+//
+// Parameters
+//  gd           - GAPS channel number
+//  desc         - string to contain channel description
+//  len          - max len allowed in desc
+//
+// Upon successful return, this function returns the
+// number of characters printed (excluding the null byte
+// used to end output to strings). The function does not
+// write more than len bytes (including the terminating null
+// byte ('\0')). If the output was truncated due to this
+//  limit, then the return value is the number of characters
+// (excluding the terminating null byte) which would have been
+// written to the final string if enough space had been
+// available. Thus, a return value of len or more means that
+// the output was truncated. If an output error is encountered,
+// a negative value is returned.
+
+int pirate_get_channel_description(int gd, char *str, int len);
 
 // Opens the gaps channel specified by parameter string.
 //
 // Channels must be opened in the same order across all
 // processes.
 
-// The return value is the input gaps descriptor, or -1 if an
+// The return value is a unique gaps descriptor, or -1 if an
 // error occurred (in which case, errno is set appropriately).
 //
 // The argument flags must have access mode O_RDONLY or O_WRONLY.

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -156,6 +156,48 @@ int pirate_get_channel_param(int gd, pirate_channel_param_t *param) {
     return 0;
 }
 
+int pirate_unparse_channel_param(const pirate_channel_param_t *param, char *desc, int len) {
+    switch (param->channel_type) {
+    case DEVICE:
+        return pirate_device_get_channel_description(&param->channel.device, desc, len);
+
+    case PIPE:
+        return pirate_pipe_get_channel_description(&param->channel.pipe, desc, len);
+
+    case UNIX_SOCKET:
+        return pirate_unix_socket_get_channel_description(&param->channel.unix_socket, desc, len);
+
+    case TCP_SOCKET:
+        return pirate_tcp_socket_get_channel_description(&param->channel.tcp_socket, desc, len);
+
+    case UDP_SOCKET:
+        return pirate_udp_socket_get_channel_description(&param->channel.udp_socket, desc, len);
+
+    case SHMEM:
+        return pirate_shmem_get_channel_description(&param->channel.shmem, desc, len);
+
+    case UDP_SHMEM:
+        return pirate_udp_shmem_get_channel_description(&param->channel.udp_shmem, desc, len);
+
+    case UIO_DEVICE:
+        return pirate_uio_get_channel_description(&param->channel.uio, desc, len);
+
+    case SERIAL:
+        return pirate_serial_get_channel_description(&param->channel.serial, desc, len);
+
+    case MERCURY:
+        return pirate_mercury_get_channel_description(&param->channel.mercury, desc, len);
+
+    case GE_ETH:
+        return pirate_ge_eth_get_channel_description(&param->channel.ge_eth, desc, len);
+
+    case INVALID:
+    default:
+        errno = ENODEV;
+        return -1;
+    }
+}
+
 int pirate_get_channel_description(int gd, char *desc, int len) {
     pirate_channel_t *channel = NULL;
 
@@ -163,47 +205,7 @@ int pirate_get_channel_description(int gd, char *desc, int len) {
         return -1;
     }
 
-    switch (channel->param.channel_type) {
-    case DEVICE:
-        return pirate_device_get_channel_description(&channel->param.channel.device, desc, len);
-
-    case PIPE:
-        return pirate_pipe_get_channel_description(&channel->param.channel.pipe, desc, len);
-
-    case UNIX_SOCKET:
-        return pirate_unix_socket_get_channel_description(&channel->param.channel.unix_socket, desc, len);
-
-    case TCP_SOCKET:
-        return pirate_tcp_socket_get_channel_description(&channel->param.channel.tcp_socket, desc, len);
-
-    case UDP_SOCKET:
-        return pirate_udp_socket_get_channel_description(&channel->param.channel.udp_socket, desc, len);
-
-    case SHMEM:
-        return pirate_shmem_get_channel_description(&channel->param.channel.shmem, desc, len);
-
-    case UDP_SHMEM:
-        return pirate_udp_shmem_get_channel_description(&channel->param.channel.udp_shmem, desc, len);
-
-    case UIO_DEVICE:
-        return pirate_uio_get_channel_description(&channel->param.channel.uio, desc, len);
-
-    case SERIAL:
-        return pirate_serial_get_channel_description(&channel->param.channel.serial, desc, len);
-
-    case MERCURY:
-        return pirate_mercury_get_channel_description(&channel->param.channel.mercury, desc, len);
-
-    case GE_ETH:
-        return pirate_ge_eth_get_channel_description(&channel->param.channel.ge_eth, desc, len);
-
-    case INVALID:
-    default:
-        errno = ENODEV;
-        return -1;
-    }
-
-    return -1;
+    return pirate_unparse_channel_param(&channel->param, desc, len);
 }
 
 static pirate_atomic_int next_gd;


### PR DESCRIPTION
Adds `int pirate_unparse_channel_param(const pirate_channel_param_t *param, char *str, int len)` to API to allow creating of description string for a parameter that is not associated with a gaps channel.