### PR TITLE
UDP channel store previous write contents

### DIFF
--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -313,7 +313,7 @@ ssize_t pirate_udp_socket_write(const pirate_udp_socket_param_t *param, udp_sock
     } while (retry);
 
     if (rv >= 0) {
-        size_t n = MIN(count, UDP_MAX_PAYLOAD);
+        size_t n = MIN(((size_t) rv), UDP_MAX_PAYLOAD);
         memcpy(ctx->prev, buf, n);
         ctx->prevcount = n;
     }

--- a/libpirate/udp_socket.h
+++ b/libpirate/udp_socket.h
@@ -20,7 +20,12 @@
 
 typedef struct {
     int sock;
+    void *prev;
+    ssize_t prevcount;
+    uint8_t init;
 } udp_socket_ctx;
+
+#define UDP_MAX_PAYLOAD 65507
 
 int pirate_udp_socket_parse_param(char *str, pirate_udp_socket_param_t *param);
 int pirate_udp_socket_get_channel_description(const pirate_udp_socket_param_t *param, char *desc, int len);


### PR DESCRIPTION
Store the previous send() request for the UDP channel. On receiving an ECONNREFUSED error when attempting a send(), then resend the previous packet from the buffer and then resend the current packet.

ECONNREFUSED are generated on even-numbered sends. On opening a UDP channel for writing send a zero byte UDP packet. This ensures that the first user pirate_write() will retry on ECONNREFUSED from the zero byte packet. On opening a UDP channel for reading then the first read silently consumes the zero byte packet.

Tested successfully on the libpirate unit tests, the channel demo, and the pnt demo. channel and pnt demos with udp channels become deterministic with this patch and behavior is invariant to the ordering and timing of starting the processes.

Not implemented for GE channel types. Need to determine whether ICMP Destination Unreachable packets are delivered in that environment. Also need to determine whether zero byte packets can be sent over GE channels without being filtered. For GE channels are either of these permissible: packets with no data and no gaps metadata, packets with no data and with gaps metadata?