### PR TITLE
UDP channel zero byte first message

### DIFF
--- a/libpirate/udp_socket.h
+++ b/libpirate/udp_socket.h
@@ -20,6 +20,7 @@
 
 typedef struct {
     int sock;
+    uint8_t init;
 } udp_socket_ctx;
 
 int pirate_udp_socket_parse_param(char *str, pirate_udp_socket_param_t *param);


### PR DESCRIPTION
Send a zero byte packet as the first packet on a UDP channel. On receiving an ECONNREFUSED error when attempting the first pirate_write() request, then resend the zero byte packet and then resend the current packet. Continue sending zero byte packets and the current packet until the zero byte packet is delivered. ECONNREFUSED errors after the first packet are propagated to the user.

ECONNREFUSED are generated on even-numbered sends. This patch ensures that the first user pirate_write() will retry on ECONNREFUSED from the zero byte packet. On opening a UDP channel for reading then the first read silently consumes the zero byte packet.

Tested successfully on the libpirate unit tests, the channel demo, and the pnt demo. channel and pnt demos with udp channels become deterministic with this patch and behavior is invariant to the ordering and timing of starting the processes.

Not implemented for GE channel types. Need to determine whether ICMP Destination Unreachable packets are delivered in that environment. Also need to determine whether zero byte packets
can be sent over GE channels without being filtered. For GE channels are either of these permissible: packets with no data and no gaps metadata, packets with no data and with gaps metadata?