### PR TITLE
RHEL gcc fixes

### DIFF
--- a/demos/cxx_demo/reader.cpp
+++ b/demos/cxx_demo/reader.cpp
@@ -14,8 +14,9 @@
  */
 
 #include <iostream>
-#include <cerrno>
 
+#include <errno.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "libpirate.h"
@@ -29,6 +30,7 @@ int main(int argc, char* argv[]) {
     pirate_channel_param_t param;
 
     pirate_init_channel_param(PIPE, &param);
+    strncpy(param.channel.pipe.path, "/tmp/gaps", sizeof(param.channel.pipe.path));
 
     gd = pirate_open_param(&param, O_RDONLY);
     if (gd < 0) {

--- a/demos/cxx_demo/writer.cpp
+++ b/demos/cxx_demo/writer.cpp
@@ -14,8 +14,9 @@
  */
 
 #include <iostream>
-#include <cerrno>
 
+#include <errno.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "libpirate.h"
@@ -29,6 +30,7 @@ int main(int argc, char* argv[]) {
     pirate_channel_param_t param;
 
     pirate_init_channel_param(PIPE, &param);
+    strncpy(param.channel.pipe.path, "/tmp/gaps", sizeof(param.channel.pipe.path));
 
     gd = pirate_open_param(&param, O_WRONLY);
     if (gd < 0) {

--- a/demos/time_demo/src/sensor_manager.c
+++ b/demos/time_demo/src/sensor_manager.c
@@ -57,7 +57,7 @@ static struct argp_option options[] = {
     { "client-to-proxy", 1000, "CONFIG", 0, "Client to proxy channel",    1 },
     { "proxy-to-client", 1001, "CONFIG", 0, "Proxy to client channel",    1 },
     { NULL,            0,  NULL,   0, GAPS_CHANNEL_OPTIONS,               2 },
-    { 0 }
+    { NULL,            0,  NULL,   0, 0,                                  0 }
 };
 
 void sensor_manager_terminate() {

--- a/demos/time_demo/src/signing_proxy.c
+++ b/demos/time_demo/src/signing_proxy.c
@@ -68,7 +68,7 @@ static struct argp_option options[] = {
     { "proxy-to-signer", 1002, "CONFIG", 0, "Proxy to signer channel",   1 },
     { "signer-to-proxy", 1003, "CONFIG", 0, "Signer to proxy channel",   1 },
     { NULL,              0,  NULL,   0, GAPS_CHANNEL_OPTIONS,            2 },
-    { 0 }
+    { NULL,              0,  NULL,   0, 0,                               0 }
 };
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {

--- a/demos/time_demo/src/signing_service.c
+++ b/demos/time_demo/src/signing_service.c
@@ -45,7 +45,7 @@ static struct argp_option options[] = {
     { "proxy-to-signer", 1000, "CONFIG", 0, "Proxy to signer channel", 1 },
     { "signer-to-proxy", 1001, "CONFIG", 0, "Signer to proxy channel", 1 },
     { NULL,         0,  NULL,      0, GAPS_CHANNEL_OPTIONS,            2 },
-    { 0 }
+    { NULL,         0,  NULL,      0, 0,                               0 }
 };
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {

--- a/demos/time_demo/src/video_sensor.c
+++ b/demos/time_demo/src/video_sensor.c
@@ -114,10 +114,11 @@ int video_sensor_initialize(const char *video_device, int display) {
 int video_sensor_read(int idx) {
     int read;
     fd_set fds;
-    struct timeval tv = {0};
+    struct timeval tv;
     char path[TS_PATH_MAX];
     FILE *f_in = NULL;
 
+    memset(&tv, 0, sizeof(tv));
     if (video_fd <= 0) {
         snprintf(path, sizeof(path) - 1, "stock/%04u.jpg", idx % 16);
         if ((f_in = fopen(path, "r")) == NULL) {

--- a/demos/time_demo/src/xwin_display.c
+++ b/demos/time_demo/src/xwin_display.c
@@ -70,11 +70,7 @@ static void convert_jpg_to_ximage(const unsigned char *buf, unsigned long len) {
     cinfo.err = jpeg_std_error(&jerr);
 
     jpeg_create_decompress(&cinfo);
-#ifdef LIBJPEG_TURBO_VERSION
-    jpeg_mem_src(&cinfo, buf, len);
-#else
     jpeg_mem_src(&cinfo, (unsigned char *) buf, len);
-#endif
     jpeg_read_header(&cinfo, 1);
     cinfo.scale_num = 1;
     cinfo.scale_denom = 1;

--- a/libpirate/mercury_cntl.c
+++ b/libpirate/mercury_cntl.c
@@ -350,10 +350,10 @@ static int mercury_cmd(mercury_cmd_t *cmd, uint32_t *attrs) {
 	int err;
 	int rv = -1;
 	ilip_nl_hdr_t *hdr = NULL;
-	ilip_nl_ctx_t ctx = { 0 };
+	ilip_nl_ctx_t ctx;
 	unsigned int dlen;
 
-
+	memset(&ctx, 0, sizeof(ctx));
 	rv = ilip_nl_connect(&ctx);
 	if (rv < 0) {
 		return rv;
@@ -396,7 +396,8 @@ done:
 int mercury_cmd_stat(uint32_t session_id, mercury_dev_stat_t *stats) {
 	int rv = -1;
 	uint32_t attrs[GAPS_ILIP_ATTR_MAX] = {0};
-	mercury_cmd_t cmd = { 0 };
+	mercury_cmd_t cmd;
+	memset(&cmd, 0, sizeof(cmd));
 	cmd.op = GAPS_ILIP_CMD_DEV_STAT;
 	cmd.req.stat.session_id = session_id;
 
@@ -410,7 +411,8 @@ int mercury_cmd_stat(uint32_t session_id, mercury_dev_stat_t *stats) {
 
 int mercury_cmd_stat_clear(uint32_t session_id) {
 	uint32_t attrs[GAPS_ILIP_ATTR_MAX] = {0};
-	mercury_cmd_t cmd = { 0 };
+	mercury_cmd_t cmd;
+	memset(&cmd, 0, sizeof(cmd));
 	cmd.op = GAPS_ILIP_CMD_DEV_STAT_CLEAR;
 	cmd.req.stat.session_id = session_id;
 


### PR DESCRIPTION
Apply syntax changes to silence older gcc warnings