### PR TITLE
WIP: time demo poll responses

### DIFF
--- a/demos/time_demo/include/gaps_packet.h
+++ b/demos/time_demo/include/gaps_packet.h
@@ -35,6 +35,7 @@
  */
 ssize_t gaps_packet_read(int gd, void *buf, uint32_t buf_len);
 
+int gaps_packet_poll(int gd);
 
 /*
  * Write a packet to the GAPS channel stream

--- a/demos/time_demo/src/gaps_packet.c
+++ b/demos/time_demo/src/gaps_packet.c
@@ -15,6 +15,7 @@
 
 #include "libpirate.h"
 #include "gaps_packet.h"
+#include <poll.h>
 
 
 static int gaps_read_len(int gd, void *buf, size_t len) {
@@ -46,6 +47,19 @@ static int gaps_write_len(int gd, void *buf, ssize_t len) {
     return 0;
 }
 
+int gaps_packet_poll(int gd) {
+    struct pollfd fds[1];
+    int fd = pirate_get_fd(gd);
+    if (fd == -1) {
+        // No file descriptor so skip the polling
+        return 1;
+    }
+    fds[0].fd = fd;
+    fds[0].events = POLLIN;
+    // If the timeout is too short then the fake requests
+    // in the proxy queue will cause this poll to timeout.
+    return poll(fds, 1, 3000);
+}
 
 ssize_t gaps_packet_read(int gd, void *buf, uint32_t buf_len) {
     /* Read the length */

--- a/demos/time_demo/src/video_sensor.c
+++ b/demos/time_demo/src/video_sensor.c
@@ -31,10 +31,16 @@ static struct v4l2_buffer video_buf;
 static void* video_mmap;
 
 static int ioctl_wait(int fd, unsigned long request, void *arg) {
-    int ret;
+    int retry, err, ret;
     do {
+        retry = 0;
+        err = errno;
         ret = ioctl(fd, request, arg);
-    } while ((ret == -1) && (errno == EINTR));
+        if ((ret == -1) && (errno == EINTR)) {
+            retry = 1;
+            errno = err;
+        }
+    } while (retry);
     return ret;
 }
 

--- a/demos/time_demo/src/xwin_display.c
+++ b/demos/time_demo/src/xwin_display.c
@@ -13,6 +13,7 @@
  * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -103,9 +104,12 @@ static void convert_jpg_to_ximage(const unsigned char *buf, unsigned long len) {
 }
 
 void xwin_display_render_jpeg(const unsigned char *buf, unsigned long len) {
+    int err;
     convert_jpg_to_ximage(buf, len);
     XPutImage(x_display, x_window, x_context, x_image, 0, 0, 0, 0, IMAGE_WIDTH, IMAGE_HEIGHT);
+    err = errno;
     XFlush(x_display);
+    errno = err;
 }
 
 static void show_line(char *msg, int msg_len, int offset) {
@@ -120,7 +124,7 @@ static void show_line(char *msg, int msg_len, int offset) {
 }
 
 void xwin_display_show_response(char *msg, int msg_len) {
-    int pos = 0, row = 0, delta;
+    int err, pos = 0, row = 0, delta;
     char *pch;
 
     // trim message prefix
@@ -147,7 +151,9 @@ void xwin_display_show_response(char *msg, int msg_len) {
         }
         row += 1;
     }
+    err = errno;
     XFlush(x_display);
+    errno = err;
 }
 
 void xwin_display_terminate() {

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -407,6 +407,18 @@ int pirate_pipe_param(int gd[2], pirate_channel_param_t *param, int flags);
 
 int pirate_pipe_parse(int gd[2], const char *param, int flags);
 
+//
+// Returns the underlying file descriptor of the gaps
+// channel if the gaps channel is implemented using
+// a file descriptor.
+//
+// On success, the number of bytes read is returned.
+// On error, -1 is returned, and errno is set appropriately.
+// errno is ENODEV if the gaps channel is not implemented
+// using a file descriptor.
+
+int pirate_get_fd(int gd);
+
 // pirate_read() attempts to read up to count bytes from
 // gaps descriptor gd into the buffer starting at buf.
 //

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -412,7 +412,7 @@ int pirate_pipe_parse(int gd[2], const char *param, int flags);
 // channel if the gaps channel is implemented using
 // a file descriptor.
 //
-// On success, the number of bytes read is returned.
+// On success, the file descriptor is returned.
 // On error, -1 is returned, and errno is set appropriately.
 // errno is ENODEV if the gaps channel is not implemented
 // using a file descriptor.

--- a/libpirate/libpirate_internal.h
+++ b/libpirate/libpirate_internal.h
@@ -22,7 +22,6 @@ extern "C" {
 
 void pirate_reset_gd();
 
-int pirate_get_fd(int gd);
 pirate_channel_param_t *pirate_get_channel_param_ref(int gd);
 
 #ifdef __cplusplus

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -465,12 +465,18 @@ int pirate_get_fd(int gd) {
     }
 
     switch (channel->param.channel_type) {
+    case DEVICE:
+        return channel->ctx.channel.device.fd;
     case PIPE:
         return channel->ctx.channel.pipe.fd;
+    case UNIX_SOCKET:
+        return channel->ctx.channel.unix_socket.sock;
     case TCP_SOCKET:
         return channel->ctx.channel.tcp_socket.sock;
     case UDP_SOCKET:
         return channel->ctx.channel.udp_socket.sock;
+    case MERCURY:
+        return channel->ctx.channel.mercury.fd;
     case GE_ETH:
         return channel->ctx.channel.ge_eth.sock;
     default:

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -475,6 +475,8 @@ int pirate_get_fd(int gd) {
         return channel->ctx.channel.tcp_socket.sock;
     case UDP_SOCKET:
         return channel->ctx.channel.udp_socket.sock;
+    case SERIAL:
+        return channel->ctx.channel.serial.fd;
     case MERCURY:
         return channel->ctx.channel.mercury.fd;
     case GE_ETH:


### PR DESCRIPTION
Modify the sensor manager to poll for responses.

Some notes on this branch:

- the signing_service must be started before the signing_proxy. This is because the signing_proxy has not been modified to poll for responses. So the signing_proxy will get stuck waiting on a response to a request that the signing_proxy sent before the signing_service was alive.
- Start the signing_service, then the signing_proxy, and then the sensor_manager. If you kill the signing_service process then the signing_proxy process will crash. I think the request queue on the signing_proxy fills up and the code does not handle that case.

I'm not concerned about these behaviors for an initial demonstration. We can show termination of the signing_proxy and when you restart the signing_proxy then the sensor_manager will continue to function. Alternatively we can implement polling in the signing_proxy. Should be very similar implementation to the polling of the sensor_manager in this branch.