### PR TITLE
WIP simplified benchmarks

### DIFF
--- a/libpirate/bench/bench.py
+++ b/libpirate/bench/bench.py
@@ -28,8 +28,9 @@ def main():
     p.add_argument("-s2", "--sync_channel_2", help="Synchronization channel 2 specification", default="tcp_socket,127.0.0.1,10001")
     p.add_argument("-l", "--message_sizes", help="Test sizes <pow,start,stop|inc,start,stop,step>", type=parse_sizes)
     p.add_argument("-i", "--iterations", help="Number of iterations for each test size", type=int)
-    p.add_argument("-d", "--packet_delay", help="Inter-packet delay in microseconds", type=int, default=0)
+    p.add_argument("-d", "--packet_delay", help="Inter-packet delay in microseconds", type=float, default=0)
     p.add_argument("-w", "--receive_timeout", help="Receive timeout in seconds", type=int, default=2)
+    p.add_argument("-v", "--validate", help="Validate received packets", action="store_true")
     args = p.parse_args()
 
     if args.message_sizes is None:
@@ -68,6 +69,9 @@ def main():
             nbytes = 1_000_000_000
 
         test_args = channel_args + ["-m", str(message_size), "-n", str(nbytes), "-d", str(args.packet_delay), "-w", str(args.receive_timeout)]
+
+        if args.validate:
+            test_args.append("-v")
 
         for _ in range(args.iterations):
             if args.role == "both" or args.role == "writer":

--- a/libpirate/bench/bench.py
+++ b/libpirate/bench/bench.py
@@ -21,12 +21,15 @@ def main():
     p = argparse.ArgumentParser(description="GAPS pirate benchmark suite")
     p.add_argument("-t", "--test_type", help="Test suite type", choices=["thr", "lat"], default="thr")
     p.add_argument("-r", "--role", help="Bench component", choices=["reader", "writer", "both"], default="both")
-    p.add_argument("-n", "--scenario_name", help="Test scenario type", default="Default bench")
+    p.add_argument("-n", "--scenario_name", help="Test scenario type", default="unnamed-scenario")
     p.add_argument("-c1", "--test_channel_1", help="Test channel 1 configuration", required=True)
     p.add_argument("-c2", "--test_channel_2", help="Test channel 2 configuration")
-    p.add_argument("-s", "--sync_channel", help="Synchronization channel specification", default="tcp_socket,127.0.0.1,10000")
+    p.add_argument("-s1", "--sync_channel_1", help="Synchronization channel 1 specification", default="tcp_socket,127.0.0.1,10000")
+    p.add_argument("-s2", "--sync_channel_2", help="Synchronization channel 2 specification", default="tcp_socket,127.0.0.1,10001")
     p.add_argument("-l", "--message_sizes", help="Test sizes <pow,start,stop|inc,start,stop,step>", type=parse_sizes)
     p.add_argument("-i", "--iterations", help="Number of iterations for each test size", type=int)
+    p.add_argument("-d", "--packet_delay", help="Inter-packet delay in microseconds", type=int, default=0)
+    p.add_argument("-w", "--receive_timeout", help="Receive timeout in seconds", type=int, default=2)
     args = p.parse_args()
 
     if args.message_sizes is None:
@@ -39,15 +42,18 @@ def main():
     if args.test_type == "thr":
         writer_app = "bench_thr_writer"
         reader_app = "bench_thr_reader"
-        channel_args = [args.test_channel_1, args.sync_channel]
-        pattern = re.compile(r'average throughput: ([0-9.]+) MB/s')
+
+        channel_args = ["-c",  args.test_channel_1, "-s", args.sync_channel_1, "-S", args.sync_channel_2]
+        pattern1 = re.compile(r'average throughput: ([0-9.]+) MB/s')
+        pattern2 = re.compile(r'drop rate: ([0-9.]+) %')
         if args.iterations is None:
             args.iterations = 64
     else:
         writer_app = "bench_lat1"
         reader_app = "bench_lat2"
         channel_args = [args.test_channel_1, args.test_channel_2, args.sync_channel]
-        pattern = re.compile(r'average latency: (\d+) ns')
+        pattern1 = re.compile(r'average latency: (\d+) ns')
+        pattern2 = None
         if args.iterations is None:
             args.iterations = 32
 
@@ -61,7 +67,7 @@ def main():
         else:
             nbytes = 1_000_000_000
 
-        test_args = channel_args + [str(message_size), str(nbytes)]
+        test_args = channel_args + ["-m", str(message_size), "-n", str(nbytes), "-d", str(args.packet_delay), "-w", str(args.receive_timeout)]
 
         for _ in range(args.iterations):
             if args.role == "both" or args.role == "writer":
@@ -75,8 +81,9 @@ def main():
 
             if args.role == "both" or args.role == "reader":
                 out, _ = reader_proc.communicate()
-                results = pattern.search(out.decode('utf-8'))
-                print(args.scenario_name, message_size, results.group(1), flush=True)
+                results1 = pattern1.search(out.decode('utf-8')).group(1)
+                results2 = "" if pattern2 is None else pattern2.search(out.decode('utf-8')).group(1)
+                print(args.scenario_name, message_size, results1, results2, flush=True)
 
 if __name__ == "__main__":
     main()

--- a/libpirate/bench/bench_lat1.c
+++ b/libpirate/bench/bench_lat1.c
@@ -24,41 +24,38 @@
 
 #include "libpirate.h"
 
-int test_gd1 = -1, test_gd2 = -1, sync_gd = -1;
+int test_gd1 = -1, test_gd2 = -1, sync_gd1 = -1, sync_gd2 = -1;
 uint64_t nbytes;
-size_t message_len, signal_len = 64;
+size_t message_len;
 char message[80];
 unsigned char *read_buffer, *write_buffer;
 
-int bench_lat_setup(char *argv[], int test_flag1, int test_flag2, int sync_flags);
+int bench_lat_setup(char *argv[], int test_flag1, int test_flag2, int sync_flag1, int sync_flag2);
 void bench_lat_close(char *argv[]);
 
 int run(int argc, char *argv[]) {
     ssize_t rv;
     uint64_t readcount = 0, writecount = 0, iter;
+    uint8_t signal = 0;
 
-    if (argc != 6) {
-        printf("./bench_lat1 [test channel 1] [test channel 2] [sync channel] [message length] [nbytes]\n\n");
+    if (argc != 7) {
+        printf("./bench_lat1 [test channel 1] [test channel 2] [sync channel 1] [sync channel 2] [message length] [nbytes]\n\n");
         return 1;
     }
 
-    if (bench_lat_setup(argv, O_WRONLY, O_RDONLY, O_RDONLY)) {
+    if (bench_lat_setup(argv, O_WRONLY, O_RDONLY, O_WRONLY, O_RDONLY)) {
         return 1;
     }
 
-    if (signal_len > nbytes) {
-        signal_len = nbytes;
-    }
-
-    rv = pirate_read(sync_gd, read_buffer, signal_len);
+    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel initial read error");
+        perror("Sync channel 2 initial read error");
         return 1;
     }
 
-    rv = pirate_write(test_gd1, write_buffer, signal_len);
+    rv = pirate_write(sync_gd1, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Test channel initial write error");
+        perror("Sync channel 1 initial write error");
         return 1;
     }
 
@@ -90,9 +87,9 @@ int run(int argc, char *argv[]) {
         }
     }
 
-    rv = pirate_read(sync_gd, write_buffer, signal_len);
+    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel terminal read error");
+        perror("Sync channel 2 terminal read error");
         return 1;
     }
 

--- a/libpirate/bench/bench_thr.h
+++ b/libpirate/bench/bench_thr.h
@@ -1,0 +1,55 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
+ */
+
+#ifndef _PIRATE_BENCH_THR_H
+#define _PIRATE_BENCH_THR_H
+
+#include <argp.h>
+#include <stdint.h>
+#include "libpirate.h"
+
+#ifndef MIN
+#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
+#endif
+
+#ifndef MAX
+#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
+#endif
+
+typedef struct {
+    int gd;
+    const char *config;
+} bench_channel_t;
+
+typedef struct {
+    bench_channel_t test_ch;
+    bench_channel_t sync_ch1;
+    bench_channel_t sync_ch2;
+    uint64_t nbytes;
+    size_t message_len;
+    int validate;
+    uint32_t tx_delay_us;
+    uint32_t rx_timeout_s;
+    uint8_t *buffer;
+    char err_msg[256];
+} bench_thr_t;
+
+void parse_args(int argc, char *argv[], bench_thr_t *bench);
+int bench_sync_write(bench_thr_t *bench, int gd);
+int bench_sync_read(bench_thr_t *bench, int gd);
+int bench_thr_setup(bench_thr_t *bench, int test_flags, int sync_flags1, int sync_flags2);
+void bench_thr_close(bench_thr_t *bench);
+
+#endif /* _PIRATE_BENCH_THR_H */

--- a/libpirate/bench/bench_thr.h
+++ b/libpirate/bench/bench_thr.h
@@ -40,9 +40,10 @@ typedef struct {
     uint64_t nbytes;
     size_t message_len;
     int validate;
-    uint32_t tx_delay_us;
+    uint64_t tx_delay_ns;
     uint32_t rx_timeout_s;
     uint8_t *buffer;
+    uint8_t *bitvector;
     char err_msg[256];
 } bench_thr_t;
 

--- a/libpirate/bench/bench_thr_common.c
+++ b/libpirate/bench/bench_thr_common.c
@@ -15,14 +15,6 @@
 
 #define _GNU_SOURCE
 
-#ifndef MAX
-#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
-#endif
-
-#ifndef MIN
-#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
-#endif
-
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
@@ -31,59 +23,176 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "libpirate.h"
+#include "bench_thr.h"
 
-extern int test_gd, sync_gd1, sync_gd2;
-extern uint64_t nbytes;
-extern size_t message_len;
-extern char message[80];
-extern unsigned char* buffer;
+static struct argp_option options[] = {
+    { "channel",     'c', "CONFIG", 0, "Test channel configuration",    0 },
+    { "sync1",       's', "CONFIG", 0, "Sync channel 1 configuration",  0 },
+    { "sync2",       'S', "CONFIG", 0, "Sync channel 2 configuration",  0 },
+    { "nbytes",      'n', "BYTES",  0, "Number of bytes to receive",    0 },
+    { "message_len", 'm', "BYTES",  0, "Transfer message size",         0 },
+    { "tx_delay",    'd', "US",     0, "Inter-message delay",           0 },
+    { "rx_timeout",  'w', "S",      0, "Message receive timeout",       0 },
+    { NULL,           0,  NULL,     0, GAPS_CHANNEL_OPTIONS,            2 },
+    { NULL,           0,  NULL,     0, 0,                               0 }
+};
 
-static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int flags) {
-    int err, fd, rv;
-    size_t bufsize;
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    bench_thr_t *bench = (bench_thr_t *) state->input;
+    char* endptr = NULL;
 
-    bufsize = 8 * message_len;
+    switch (key) {
 
-    switch (param->channel_type) {
+    case 'c':
+        bench->test_ch.config = arg;
+        break;
+
+    case 's':
+        bench->sync_ch1.config = arg;
+        break;
+
+    case 'S':
+        bench->sync_ch2.config = arg;
+        break;
+
+    case 'n':
+        bench->nbytes = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'm':
+        bench->message_len = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'd':
+        bench->tx_delay_us = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'w':
+        bench->rx_timeout_s = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case ARGP_KEY_END:
+        if (bench->test_ch.config == NULL) {
+            argp_error(state, "Test channel configuration is not specified");
+        }
+
+        if (bench->sync_ch1.config == NULL) {
+            argp_error(state, "Sync channel 1 configuration is not specified");
+        }
+
+        if (bench->sync_ch2.config == NULL) {
+            argp_error(state, "Sync channel 2 configuration is not specified");
+        }
+
+        if (strstr(bench->sync_ch1.config, "tcp_socket,") == NULL) {
+            argp_error(state,"Sync channel 1 '%s' must be a tcp_socket",
+                        bench->sync_ch1.config);
+        }
+
+        if (strstr(bench->sync_ch2.config, "tcp_socket,") == NULL) {
+            argp_error(state,"Sync channel 2 '%s' must be a tcp_socket",
+                        bench->sync_ch2.config);
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+void parse_args(int argc, char *argv[], bench_thr_t *bench) {
+    /* Default parameters */
+    bench->test_ch.config  = NULL;
+    bench->test_ch.gd      = -1;
+    bench->sync_ch1.config = NULL;
+    bench->sync_ch1.gd     = -1;
+    bench->sync_ch2.config = NULL;
+    bench->sync_ch2.gd     = -1;
+    bench->nbytes          = 1024;
+    bench->message_len     = 128;
+    bench->tx_delay_us     = 0;
+    bench->rx_timeout_s    = 2;
+
+    struct argp argp = {
+        .options = options,
+        .parser = parse_opt,
+        .args_doc = NULL,
+        .doc = "PIRATE throughput benchmark",
+        .children = NULL,
+        .help_filter = NULL,
+        .argp_domain = NULL
+    };
+
+    argp_parse(&argp, argc, argv, 0, 0, bench);
+}
+
+static int bench_thr_open(bench_thr_t *bench, int flags) {
+    pirate_channel_param_t param;
+    size_t bufsize = 8 * bench->message_len;
+    int err, fd;
+
+    if (pirate_parse_channel_param(bench->test_ch.config, &param)) {
+        fprintf(stderr, "Unable to parse test channel \"%s\"\n",
+            bench->test_ch.config);
+        return -1;
+    }
+
+    switch (param.channel_type) {
         case SHMEM:
-            if ((bufsize > DEFAULT_SMEM_BUF_LEN) && (param->channel.shmem.buffer_size == 0)) {
-                param->channel.shmem.buffer_size = MIN(bufsize, 524288);
+            if ((bufsize > DEFAULT_SMEM_BUF_LEN) && (param.channel.shmem.buffer_size == 0)) {
+                param.channel.shmem.buffer_size = MIN(bufsize, 524288);
             }
             break;
         case UNIX_SOCKET:
-            if ((bufsize > 212992) && (param->channel.unix_socket.buffer_size == 0)) {
-                param->channel.unix_socket.buffer_size = bufsize;
+            if ((bufsize > 212992) && (param.channel.unix_socket.buffer_size == 0)) {
+                param.channel.unix_socket.buffer_size = bufsize;
             }
             break;
         case UDP_SHMEM:
-            if (param->channel.udp_shmem.packet_size == 0) {
-                param->channel.udp_shmem.packet_size = MAX(message_len, 64);
+            if (param.channel.udp_shmem.packet_size == 0) {
+                param.channel.udp_shmem.packet_size = MAX(bench->message_len, 64);
             }
             break;
         default:
             break;
     }
 
-    rv = pirate_open_param(param, flags);
-    if (rv < 0) {
-        snprintf(message, sizeof(message), "Unable to open test channel \"%s\"", param_str);
-        perror(message);
-        if (param->channel_type == UNIX_SOCKET) {
+    bench->test_ch.gd = pirate_open_param(&param, flags);
+    if (bench->test_ch.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open test channel \"%s\"",
+                    bench->test_ch.config);
+        perror(bench->err_msg);
+        if (param.channel_type == UNIX_SOCKET) {
             fprintf(stderr, "Check /proc/sys/net/core/wmem_max\n");
         }
-        return rv;
+        return bench->test_ch.gd;
     }
+
     err = errno;
-    fd = pirate_get_fd(rv);
+    fd = pirate_get_fd(bench->test_ch.gd);
     errno = err;
-    switch (param->channel_type) {
+    switch (param.channel_type) {
         case PIPE:
             if (fcntl(fd, F_SETPIPE_SZ, bufsize) < 0) {
-                snprintf(message, sizeof(message),
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
                     "Unable to set F_SETPIPE_SZ option on test channel \"%s\"",
-                    param_str);
-                perror(message);
+                    bench->test_ch.config);
+                perror(bench->err_msg);
                 fprintf(stderr, "Check /proc/sys/fs/pipe-max-size\n");
                 return -1;
             }
@@ -91,14 +200,14 @@ static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int fl
         case UDP_SOCKET:
         case GE_ETH: {
             struct timeval tv;
-            tv.tv_sec = 2;
+            tv.tv_sec = bench->rx_timeout_s;
             tv.tv_usec = 0;
             if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv,
                         sizeof(tv)) < 0) {
-                snprintf(message, sizeof(message),
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
                     "Unable to set SO_RCVTIMEO option on test channel \"%s\"",
-                    param_str);
-                perror(message);
+                    bench->test_ch.config);
+                perror(bench->err_msg);
                 return -1;
             }
             break;
@@ -109,10 +218,10 @@ static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int fl
             socket_reset.l_linger = 0;
             if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &socket_reset,
                         sizeof(socket_reset)) < 0) {
-                snprintf(message, sizeof(message),
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
                     "Unable to set SO_LINGER option on test channel \"%s\"",
-                    param_str);
-                perror(message);
+                    bench->test_ch.config);
+                perror(bench->err_msg);
                 return -1;
             }
             break;
@@ -120,87 +229,68 @@ static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int fl
         default:
             break;
     }
-
-    return rv;
+    return 0;
 }
 
-int bench_thr_setup(char *argv[], int test_flags, int sync_flag1, int sync_flag2) {
-    char* endptr;
-    pirate_channel_param_t param;
-
-    if (strstr(argv[2], "tcp_socket,") == NULL) {
-        fprintf(stderr, "Sync channel 1 %s must be a tcp socket\n", argv[2]);
-        return 1;
+int bench_thr_setup(bench_thr_t *bench, int test_flags, int sync_flags1, int sync_flags2) {
+    /* Open the synchronization channels */
+    bench->sync_ch1.gd = pirate_open_parse(bench->sync_ch1.config, sync_flags1);
+    if (bench->sync_ch1.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open sync channel 1 \"%s\"",
+                    bench->sync_ch1.config);
+        perror(bench->err_msg);
+        return -1;
     }
 
-    if (strstr(argv[3], "tcp_socket,") == NULL) {
-        fprintf(stderr, "Sync channel 2 %s must be a tcp socket\n", argv[3]);
-        return 1;
+    bench->sync_ch2.gd = pirate_open_parse(bench->sync_ch2.config, sync_flags2);
+    if (bench->sync_ch2.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open sync channel 2 \"%s\"",
+                    bench->sync_ch2.config);
+        perror(bench->err_msg);
+        return -1;
     }
 
-    if (pirate_parse_channel_param(argv[1], &param)) {
-        fprintf(stderr, "Unable to parse test channel \"%s\"\n", argv[1]);
-        return 1;
+    /* Open the test channel */
+    if (bench_thr_open(bench, test_flags) != 0) {
+        return -1;
     }
 
-    sync_gd1 = pirate_open_parse(argv[2], sync_flag1);
-    if (sync_gd1 < 0) {
-        snprintf(message, sizeof(message), "Unable to open sync channel 1 \"%s\"", argv[2]);
-        perror(message);
-        return 1;
-    }
+    /* Truncate nbytes to be divisible by message_len */
+    bench->nbytes = bench->message_len * (bench->nbytes / bench->message_len);
 
-    sync_gd2 = pirate_open_parse(argv[3], sync_flag2);
-    if (sync_gd2 < 0) {
-        snprintf(message, sizeof(message), "Unable to open sync channel 2 \"%s\"", argv[3]);
-        perror(message);
-        return 1;
-    }
-
-    message_len = strtol(argv[4], &endptr, 10);
-    if (*endptr != '\0') {
-        fprintf(stderr, "Unable to parse message length \"%s\"\n", argv[4]);
-        return 1;
-    }
-
-    nbytes = strtol(argv[5], &endptr, 10);
-    if (*endptr != '\0') {
-        snprintf(message, sizeof(message), "Unable to parse number of bytes \"%s\"", argv[5]);
-        perror(message);
-        return 1;
-    }
-
-    // truncate nbytes to be divisible by message_len
-    nbytes = message_len * (nbytes / message_len);
-
-    test_gd = bench_thr_open(argv[1], &param, test_flags);
-    if (test_gd < 0) {
-        return 1;
-    }
-
-    buffer = malloc(nbytes);
-    if (buffer == NULL) {
-        fprintf(stderr, "Failed to allocate buffer of %zu bytes\n", nbytes);
-        return 1;
+    bench->buffer = calloc(bench->nbytes, 1);
+    if (bench->buffer == NULL) {
+        fprintf(stderr, "Failed to allocate buffer of %zu bytes\n",
+                    bench->nbytes);
+        return -1;
     }
 
     return 0;
 }
 
-void bench_thr_close(char *argv[]) {
-    if (buffer != NULL) {
-        free(buffer);
+void bench_thr_close(bench_thr_t *bench) {
+    if (bench->buffer != NULL) {
+        free(bench->buffer);
+        bench->buffer = NULL;
     }
-    if ((test_gd >= 0) && (pirate_close(test_gd) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close test channel %s", argv[1]);
-        perror(message);
+
+    if ((bench->test_ch.gd >= 0) && (pirate_close(bench->test_ch.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close test channel %s", bench->test_ch.config);
+        perror(bench->err_msg);
     }
-    if ((sync_gd1 >= 0) && (pirate_close(sync_gd1) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close sync channel 1 %s", argv[2]);
-        perror(message);
+
+    if ((bench->sync_ch1.gd >= 0) && (pirate_close(bench->sync_ch1.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close sync channel 1 %s", bench->sync_ch1.config);
+        perror(bench->err_msg);
     }
-    if ((sync_gd2 >= 0) && (pirate_close(sync_gd2) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close sync channel 2 %s", argv[3]);
-        perror(message);
+
+    if ((bench->sync_ch2.gd >= 0) && (pirate_close(bench->sync_ch2.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close sync channel 2 %s", bench->sync_ch2.config);
+        perror(bench->err_msg);
     }
 }

--- a/libpirate/bench/bench_thr_common.c
+++ b/libpirate/bench/bench_thr_common.c
@@ -70,7 +70,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
         }
         break;
 
-   case 'v':
+    case 'v':
         bench->validate = 1;
         break;
 

--- a/libpirate/bench/bench_thr_reader.c
+++ b/libpirate/bench/bench_thr_reader.c
@@ -19,6 +19,7 @@
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 #endif
 
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -27,58 +28,62 @@
 
 #include "libpirate.h"
 
-int test_gd = -1, sync_gd = -1;
+int test_gd = -1, sync_gd1 = -1, sync_gd2 = -1;
 uint64_t nbytes;
-size_t message_len, signal_len = 64;
+size_t message_len;
 char message[80];
 unsigned char* buffer;
 
-int bench_thr_setup(char *argv[], int test_flags, int sync_flags);
+int bench_thr_setup(char *argv[], int test_flags, int sync_flag1, int sync_flag2);
 void bench_thr_close(char *argv[]);
 
 int run(int argc, char *argv[]) {
     ssize_t rv;
     uint64_t readcount = 0, iter, delta;
     struct timespec start, stop;
+    int timeout = 0;
+    uint8_t signal = 1;
 
-    if (argc != 5) {
-        printf("./bench_thr_reader [test channel] [sync channel] [message length] [nbytes]\n\n");
+    if (argc != 6) {
+        printf("./bench_thr_reader [test channel] [sync channel 1] [sync channel 2] [message length] [nbytes]\n\n");
         return 1;
     }
 
-    if (bench_thr_setup(argv, O_RDONLY, O_WRONLY)) {
+    if (bench_thr_setup(argv, O_RDONLY, O_RDONLY, O_WRONLY)) {
         return 1;
-    }
-
-    if (signal_len > nbytes) {
-        signal_len = nbytes;
     }
 
     memset(buffer, 0, nbytes);
 
-    rv = pirate_write(sync_gd, buffer, signal_len);
+    rv = pirate_write(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel initial write error");
+        perror("Sync channel 2 initial write error");
         return 1;
     }
 
-    rv = pirate_read(test_gd, buffer, signal_len);
+    rv = pirate_read(sync_gd1, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Test channel initial read error");
+        perror("Sync channel 1 initial read error");
         return 1;
     }
+
     iter = nbytes / message_len;
     if (clock_gettime(CLOCK_MONOTONIC, &start) < 0) {
       perror("clock_gettime start");
       return 1;
     }
-    for (uint64_t i = 0; i < iter; i++) {
+    for (uint64_t i = 0; i < iter && !timeout; i++) {
         size_t count;
 
         count = message_len;
         while (count > 0) {
             rv = pirate_read(test_gd, buffer + readcount, count);
             if (rv < 0) {
+                if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                    errno = 0;
+                    timeout = 1;
+                    break;
+                }
                 perror("Test channel read error");
                 return 1;
             }
@@ -91,25 +96,33 @@ int run(int argc, char *argv[]) {
       return 1;
     }
 
-    rv = pirate_write(sync_gd, buffer, signal_len);
+    rv = pirate_write(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel terminating write error");
+        perror("Sync channel 2 terminating write error");
         return 1;
     }
 
-    for (uint64_t i = 0; i < nbytes; i++) {
-        if (buffer[i] != (unsigned char) (i % UCHAR_MAX)) {
-            fprintf(stderr, "At position %zu expected %zu and read character %d\n",
-                i, (i % UCHAR_MAX), (int) buffer[i]);
-            break;
+    for (uint64_t i = 0; i < iter; i++) {
+        for (uint64_t j = 0; j < message_len && (i * message_len + j) < readcount; j++) {
+            if (buffer[i * message_len + j] != (unsigned char) (j & 0xFF)) {
+                fprintf(stderr, "At position %zu of packet %zu expected %zu and read character %d\n",
+                j, i, (j & 0xFF), (int) buffer[i * message_len + j]);
+            }
         }
     }
+
     delta = ((stop.tv_sec - start.tv_sec) * 1000000000ll +
              (stop.tv_nsec - start.tv_nsec));
+    if (timeout) {
+        // subtract timeout wait
+        delta -= 2 * 1000000000ll;
+    }
     // 1e9 nanoseconds per second
     // 1e6 bytes per megabytes
     printf("average throughput: %f MB/s\n",
-           ((1e9 / 1e6) * nbytes) / delta);
+           ((1e9 / 1e6) * readcount) / delta);
+    printf("drop rate: %f %%\n",
+        ((nbytes - readcount) / (nbytes * 1.0)) * 100.0);
 
     return 0;
 }

--- a/libpirate/bench/bench_thr_writer.c
+++ b/libpirate/bench/bench_thr_writer.c
@@ -13,86 +13,83 @@
  * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
  */
 
-#ifndef MIN
-#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
-#endif
-
+#include <time.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "bench_thr.h"
 
-#include "libpirate.h"
-
-int test_gd = -1, sync_gd1 = -1, sync_gd2 = -1;
-uint64_t nbytes;
-size_t message_len;
-char message[80];
-unsigned char* buffer;
-
-int bench_thr_setup(char *argv[], int test_flags, int sync_flag1, int sync_flag2);
-void bench_thr_close(char *argv[]);
-
-int run(int argc, char *argv[]) {
+int run(bench_thr_t *bench) {
     ssize_t rv;
-    uint64_t writecount = 0, iter;
-    uint8_t signal = 0;
+    const uint64_t iter = bench->nbytes / bench->message_len;
+    uint64_t write_off = 0;
+    uint8_t signal = 1;
 
-    if (argc != 6) {
-        printf("./bench_thr_writer [test channel] [sync channel 1] [sync channel 2] [message length] [nbytes]\n\n");
-        return 1;
+    const struct timespec ts = {
+        .tv_sec = bench->tx_delay_us / 1000000,
+        .tv_nsec = (bench->tx_delay_us % 1000000) * 1000
+    };
+
+    /* Open and configure synchronization and test channels */
+    if (bench_thr_setup(bench, O_WRONLY, O_WRONLY, O_RDONLY)) {
+        return -1;
     }
 
-    if (bench_thr_setup(argv, O_WRONLY, O_WRONLY, O_RDONLY)) {
-        return 1;
-    }
-
-    iter = nbytes / message_len;
-
+    /* Initialize the write buffer */
     for (uint64_t i = 0; i < iter; i++) {
-        for (uint64_t j = 0; j < message_len; j++) {
-            buffer[i * message_len + j] = (unsigned char)(j & 0xFF);
+        for (uint64_t j = 0; j < bench->message_len; j++) {
+            uint64_t pos = i * bench->message_len + j;
+            bench->buffer[pos] = (unsigned char)(j & 0xFF);
         }
     }
 
-    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
+    rv = pirate_read(bench->sync_ch2.gd, &signal, sizeof(signal));
     if (rv < 0) {
         perror("Sync channel 2 initial read error");
-        return 1;
+        return -1;
     }
 
-    rv = pirate_write(sync_gd1, &signal, sizeof(signal));
+    rv = pirate_write(bench->sync_ch1.gd, &signal, sizeof(signal));
     if (rv < 0) {
         perror("Sync channel 1 initial write error");
-        return 1;
+        return -1;
     }
 
     for (uint64_t i = 0; i < iter; i++) {
-        size_t count;
-
-        count = message_len;
+        size_t count = bench->message_len;
         while (count > 0) {
-            rv = pirate_write(test_gd, buffer + writecount, count);
+            rv = pirate_write(bench->test_ch.gd, bench->buffer + write_off, count);
             if (rv < 0) {
                 perror("Test channel write error");
-                return 1;
+                return -1;
             }
-            writecount += rv;
+            write_off += rv;
             count -= rv;
+            if (bench->tx_delay_us != 0) {
+                nanosleep(&ts, NULL);
+            }
         }
     }
 
-    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
+    /* Read sync from the reader */
+    rv = pirate_read(bench->sync_ch2.gd, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel terminating read error");
-        return 1;
+        perror("Sync channel 2 terminating read error");
+        return -1;
     }
 
     return 0;
 }
 
 int main(int argc, char *argv[]) {
-    int rv = run(argc, argv);
-    bench_thr_close(argv);
+    bench_thr_t bench;
+    memset(&bench, 0, sizeof(bench));
+    parse_args(argc, argv, &bench);
+    int rv = run(&bench);
+    bench_thr_close(&bench);
     return rv;
 }
+
+
+


### PR DESCRIPTION
This branch has a few simplifications to the benchmarks.

On master, the benchmarks use one of the tests channels for both sending test data and an initial synchronization. This was a hack that I have replaced. I realized that the initial synchronization needed to be a two-way handshake. Originally, I did not want to insert a second synchronization channel. But that is the correct approach. Using the second sync channel eliminates the need for a signal_len and it stops using the buffer for both test data and synchronization data.

In the throughput benchmarks, sync channel 1 is opened with the same access mode as the test channel. Sync channel 2 is opened with the opposite access mode. In the latency benchmarks, sync channel 1 and test channel 1 are opened with the same access mode. Sync channel 2 and test channel 2 are opened with the same access mode.

Added SO_RCVTIMEO socket option to UDP and GE_ETH channel types. Currently hard-coded to a timeout of 2 seconds. That will become a command-line option. I will add a TODO list in the comments of work that needs to be done before merging.