### PR TITLE
benchmark cleanup

### DIFF
--- a/demos/channel_demo/README.md
+++ b/demos/channel_demo/README.md
@@ -104,7 +104,7 @@ User-provided binary messages are sent as a whole
 
 #### Continuous Mode, Inter-Message Delay, and Message Flood Options
 Use ```-d us``` option to set inter-message delay in microseconds. The default
-is ```1,000,000 us```
+is ```1,000,000 us```. Fractions of a microsecond are accepted.
 
 By default the writer stops sending test messages after the end of the test
 length sequence or after a single user-provided binary message. The ```-c```

--- a/libpirate/bench/README.md
+++ b/libpirate/bench/README.md
@@ -1,0 +1,103 @@
+# Benchmarks
+
+This directory has throughput benchmarks and latency benchmarks
+for the libpirate library.
+
+The throughput benchmarks use one gaps channel to measure
+the MB/sec transmitted across the channel. The latency benchmarks
+use two gaps channels in opposite directions to measure
+the roundtrip time (ns) it takes to send and receive a message.
+
+Throughput and latency benchmarks require two additional gaps channels
+used for synchronization. The synchronization
+channels must be TCP sockets. The synchronization channels
+are only used during benchmark initialization and termination.
+
+## bench.py
+
+`bench.py` is a wrapper script that can run the benchmarks
+for several iterations across different message sizes.
+If you are running benchmarks on a single machine then use
+`bench.py -r both`. If you are running benchmarks across
+two machines then one machine will use `bench.py -r reader`
+and the other will use `bench.py -r writer`.
+
+The following command-line options are available:
+
+```
+usage: bench.py [-h] [-t {thr,lat}] [-r {reader,writer,both}]
+                [-n SCENARIO_NAME] -c1 TEST_CHANNEL_1 [-c2 TEST_CHANNEL_2]
+                [-s1 SYNC_CHANNEL_1] [-s2 SYNC_CHANNEL_2] [-l MESSAGE_SIZES]
+                [-i ITERATIONS] [-d PACKET_DELAY] [-w RECEIVE_TIMEOUT] [-v]
+
+GAPS pirate benchmark suite
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -t {thr,lat}, --test_type {thr,lat}
+                        Test suite type (required)
+  -r {reader,writer,both}, --role {reader,writer,both}
+                        Bench component
+  -n SCENARIO_NAME, --scenario_name SCENARIO_NAME
+                        Test scenario type
+  -c1 TEST_CHANNEL_1, --test_channel_1 TEST_CHANNEL_1
+                        Test channel 1 configuration (required)
+  -c2 TEST_CHANNEL_2, --test_channel_2 TEST_CHANNEL_2
+                        Test channel 2 configuration (required for lat)
+  -s1 SYNC_CHANNEL_1, --sync_channel_1 SYNC_CHANNEL_1
+                        Synchronization channel 1 specification
+  -s2 SYNC_CHANNEL_2, --sync_channel_2 SYNC_CHANNEL_2
+                        Synchronization channel 2 specification
+  -l MESSAGE_SIZES, --message_sizes MESSAGE_SIZES
+                        Test sizes <pow,start,stop|inc,start,stop,step>
+  -i ITERATIONS, --iterations ITERATIONS
+                        Number of iterations for each test size (default 64)
+  -d PACKET_DELAY, --packet_delay PACKET_DELAY
+                        Inter-packet delay in microseconds (default 0)
+  -w RECEIVE_TIMEOUT, --receive_timeout RECEIVE_TIMEOUT
+                        Receive timeout in seconds (default 2)
+  -v, --validate        Validate received packets (default false)
+```
+
+## Throughput
+
+`bench_thr_reader` and `bench_thr_writer` are the 
+executable programs. The reader opens the test channel
+in O_RDONLY mode, sync channel 1 in O_RDONLY mode, and
+sync channel 2 in O_WRONLY mode. The writer opens the
+test channel is O_WRONLY mode, sync channel 1 in O_RDONLY
+mode, and sync channel 2 in O_WRONLY mode.
+
+The following command-line options are available:
+
+```
+  -c, --channel=CONFIG       Test channel configuration
+  -d, --tx_delay=USEC        Inter-message delay
+  -m, --message_len=BYTES    Transfer message size
+  -n, --nbytes=BYTES         Number of bytes to receive
+  -s, --sync1=CONFIG         Sync channel 1 configuration
+  -S, --sync2=CONFIG         Sync channel 2 configuration
+  -v, --validate             Validate received data
+  -w, --rx_timeout=SEC       Message receive timeout
+```
+
+## Latency
+
+`bench_lat1` and `bench_lat1` are the executable programs.
+`bench_lat1` (considered to be the "writer" in bench.py)
+opens test channel 1 and sync channel 1 in O_WRONLY mode,
+and test channel 2 and sync channel 2 in O_RDONLY mode.
+`bench_lat2` (considered to be the "reader") does the opposite.
+
+The following command-line options are available:
+
+```
+  -c, --channel1=CONFIG      Test channel 1 configuration
+  -C, --channel2=CONFIG      Test channel 2 configuration
+  -d, --tx_delay=USEC        Inter-message delay
+  -m, --message_len=BYTES    Transfer message size
+  -n, --nbytes=BYTES         Number of bytes to receive
+  -s, --sync1=CONFIG         Sync channel 1 configuration
+  -S, --sync2=CONFIG         Sync channel 2 configuration
+  -w, --rx_timeout=SEC       Message receive timeout
+```

--- a/libpirate/bench/README.md
+++ b/libpirate/bench/README.md
@@ -61,7 +61,7 @@ optional arguments:
 
 ## Throughput
 
-`bench_thr_reader` and `bench_thr_writer` are the 
+`bench_thr_reader` and `bench_thr_writer` are the
 executable programs. The reader opens the test channel
 in O_RDONLY mode, sync channel 1 in O_RDONLY mode, and
 sync channel 2 in O_WRONLY mode. The writer opens the

--- a/libpirate/bench/bench.py
+++ b/libpirate/bench/bench.py
@@ -17,6 +17,14 @@ def parse_sizes(arg):
     print("Invalid length specifications '{}'".format(arg), file=sys.stderr)
     sys,exit(1)
 
+def extract(out, pattern):
+    if pattern is None:
+        return None
+    s = pattern.search(out.decode('utf-8'))
+    if s is None:
+        return None
+    return s.group(1)
+
 def main():
     p = argparse.ArgumentParser(description="GAPS pirate benchmark suite")
     p.add_argument("-t", "--test_type", help="Test suite type", choices=["thr", "lat"], default="thr")
@@ -52,7 +60,7 @@ def main():
     else:
         writer_app = "bench_lat1"
         reader_app = "bench_lat2"
-        channel_args = [args.test_channel_1, args.test_channel_2, args.sync_channel]
+        channel_args = ["-c",  args.test_channel_1, "-C",  args.test_channel_2, "-s", args.sync_channel_1, "-S", args.sync_channel_2]
         pattern1 = re.compile(r'average latency: (\d+) ns')
         pattern2 = None
         if args.iterations is None:
@@ -85,8 +93,12 @@ def main():
 
             if args.role == "both" or args.role == "reader":
                 out, _ = reader_proc.communicate()
-                results1 = pattern1.search(out.decode('utf-8')).group(1)
-                results2 = "" if pattern2 is None else pattern2.search(out.decode('utf-8')).group(1)
+                results1 = extract(out, pattern1)
+                results2 = extract(out, pattern2)
+                if results1 is None:
+                    results1 = "error"
+                if results2 is None:
+                    results2 = ""
                 print(args.scenario_name, message_size, results1, results2, flush=True)
 
 if __name__ == "__main__":

--- a/libpirate/bench/bench.py
+++ b/libpirate/bench/bench.py
@@ -28,8 +28,9 @@ def main():
     p.add_argument("-s2", "--sync_channel_2", help="Synchronization channel 2 specification", default="tcp_socket,127.0.0.1,10001")
     p.add_argument("-l", "--message_sizes", help="Test sizes <pow,start,stop|inc,start,stop,step>", type=parse_sizes)
     p.add_argument("-i", "--iterations", help="Number of iterations for each test size", type=int)
-    p.add_argument("-d", "--packet_delay", help="Inter-packet delay in microseconds", type=int, default=0)
+    p.add_argument("-d", "--packet_delay", help="Inter-packet delay in microseconds", type=float, default=0)
     p.add_argument("-w", "--receive_timeout", help="Receive timeout in seconds", type=int, default=2)
+    p.add_argument("-v", "--validate", help="Validate received packets", action="store_true")
     args = p.parse_args()
 
     if args.message_sizes is None:
@@ -68,6 +69,9 @@ def main():
             nbytes = 1_000_000_000
 
         test_args = channel_args + ["-m", str(message_size), "-n", str(nbytes), "-d", str(args.packet_delay), "-w", str(args.receive_timeout)]
+
+        if args.validate:
+            test_args.append("-v")
 
         for _ in range(args.iterations):
             if args.role == "both" or args.role == "writer":

--- a/libpirate/bench/bench.py
+++ b/libpirate/bench/bench.py
@@ -21,12 +21,15 @@ def main():
     p = argparse.ArgumentParser(description="GAPS pirate benchmark suite")
     p.add_argument("-t", "--test_type", help="Test suite type", choices=["thr", "lat"], default="thr")
     p.add_argument("-r", "--role", help="Bench component", choices=["reader", "writer", "both"], default="both")
-    p.add_argument("-n", "--scenario_name", help="Test scenario type", default="Default bench")
+    p.add_argument("-n", "--scenario_name", help="Test scenario type", default="unnamed-scenario")
     p.add_argument("-c1", "--test_channel_1", help="Test channel 1 configuration", required=True)
     p.add_argument("-c2", "--test_channel_2", help="Test channel 2 configuration")
-    p.add_argument("-s", "--sync_channel", help="Synchronization channel specification", default="tcp_socket,127.0.0.1,10000")
+    p.add_argument("-s1", "--sync_channel_1", help="Synchronization channel 1 specification", default="tcp_socket,127.0.0.1,10000")
+    p.add_argument("-s2", "--sync_channel_2", help="Synchronization channel 2 specification", default="tcp_socket,127.0.0.1,10001")
     p.add_argument("-l", "--message_sizes", help="Test sizes <pow,start,stop|inc,start,stop,step>", type=parse_sizes)
     p.add_argument("-i", "--iterations", help="Number of iterations for each test size", type=int)
+    p.add_argument("-d", "--packet_delay", help="Inter-packet delay in microseconds", type=int, default=0)
+    p.add_argument("-w", "--receive_timeout", help="Receive timeout in seconds", type=int, default=2)
     args = p.parse_args()
 
     if args.message_sizes is None:
@@ -39,15 +42,18 @@ def main():
     if args.test_type == "thr":
         writer_app = "bench_thr_writer"
         reader_app = "bench_thr_reader"
-        channel_args = [args.test_channel_1, args.sync_channel]
-        pattern = re.compile(r'average throughput: ([0-9.]+) MB/s')
+
+        channel_args = ["-c",  args.test_channel_1, "-s", args.sync_channel_1, "-S", args.sync_channel_2]
+        pattern1 = re.compile(r'average throughput: ([0-9.]+) MB/s')
+        pattern2 = re.compile(r'drop rate: ([0-9.]+) %')
         if args.iterations is None:
             args.iterations = 64
     else:
         writer_app = "bench_lat1"
         reader_app = "bench_lat2"
         channel_args = [args.test_channel_1, args.test_channel_2, args.sync_channel]
-        pattern = re.compile(r'average latency: (\d+) ns')
+        pattern1 = re.compile(r'average latency: (\d+) ns')
+        pattern2 = None
         if args.iterations is None:
             args.iterations = 32
 
@@ -61,7 +67,7 @@ def main():
         else:
             nbytes = 1_000_000_000
 
-        test_args = channel_args + [str(message_size), str(nbytes)]
+        test_args = channel_args + ["-m", str(message_size), "-n", str(nbytes), "-d", str(args.packet_delay), "-w", str(args.receive_timeout)]
 
         for _ in range(args.iterations):
             if args.role == "both" or args.role == "writer":
@@ -75,8 +81,9 @@ def main():
 
             if args.role == "both" or args.role == "reader":
                 out, _ = reader_proc.communicate()
-                results = pattern.search(out.decode('utf-8'))
-                print(args.scenario_name, message_size, results.group(1), flush=True)
+                results1 = pattern1.search(out.decode('utf-8')).group(1)
+                results2 = "" if pattern2 is None else pattern2.search(out.decode('utf-8')).group(1)
+                print(args.scenario_name, message_size, results1, results2, flush=True)
 
 if __name__ == "__main__":
     main()

--- a/libpirate/bench/bench_lat.h
+++ b/libpirate/bench/bench_lat.h
@@ -35,7 +35,7 @@ typedef struct {
 
 typedef struct {
     bench_channel_t test_ch1;
-    bench_channel_t test_ch2;    
+    bench_channel_t test_ch2;
     bench_channel_t sync_ch1;
     bench_channel_t sync_ch2;
     uint64_t nbytes;
@@ -43,7 +43,7 @@ typedef struct {
     uint64_t tx_delay_ns;
     uint32_t rx_timeout_s;
     uint8_t *read_buffer;
-    uint8_t *write_buffer;    
+    uint8_t *write_buffer;
     char err_msg[256];
 } bench_lat_t;
 

--- a/libpirate/bench/bench_lat.h
+++ b/libpirate/bench/bench_lat.h
@@ -13,8 +13,8 @@
  * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
  */
 
-#ifndef _PIRATE_BENCH_THR_H
-#define _PIRATE_BENCH_THR_H
+#ifndef _PIRATE_BENCH_LAT_H
+#define _PIRATE_BENCH_LAT_H
 
 #include <argp.h>
 #include <stdint.h>
@@ -34,21 +34,22 @@ typedef struct {
 } bench_channel_t;
 
 typedef struct {
-    bench_channel_t test_ch;
+    bench_channel_t test_ch1;
+    bench_channel_t test_ch2;    
     bench_channel_t sync_ch1;
     bench_channel_t sync_ch2;
     uint64_t nbytes;
     size_t message_len;
-    int validate;
     uint64_t tx_delay_ns;
     uint32_t rx_timeout_s;
-    uint8_t *buffer;
-    uint8_t *bitvector;
+    uint8_t *read_buffer;
+    uint8_t *write_buffer;    
     char err_msg[256];
-} bench_thr_t;
+} bench_lat_t;
 
-void parse_args(int argc, char *argv[], bench_thr_t *bench);
-int bench_thr_setup(bench_thr_t *bench, int test_flags, int sync_flags1, int sync_flags2);
-void bench_thr_close(bench_thr_t *bench);
+void parse_args(int argc, char *argv[], bench_lat_t *bench);
+int bench_lat_setup(bench_lat_t *bench, int test_flags1, int test_flags2, int sync_flags1, int sync_flags2);
+void bench_lat_close(bench_lat_t *bench);
+int bench_lat_busysleep(uint32_t nanoseconds);
 
-#endif /* _PIRATE_BENCH_THR_H */
+#endif /* _PIRATE_BENCH_LAT_H */

--- a/libpirate/bench/bench_lat1.c
+++ b/libpirate/bench/bench_lat1.c
@@ -24,41 +24,38 @@
 
 #include "libpirate.h"
 
-int test_gd1 = -1, test_gd2 = -1, sync_gd = -1;
+int test_gd1 = -1, test_gd2 = -1, sync_gd1 = -1, sync_gd2 = -1;
 uint64_t nbytes;
-size_t message_len, signal_len = 64;
+size_t message_len;
 char message[80];
 unsigned char *read_buffer, *write_buffer;
 
-int bench_lat_setup(char *argv[], int test_flag1, int test_flag2, int sync_flags);
+int bench_lat_setup(char *argv[], int test_flag1, int test_flag2, int sync_flag1, int sync_flag2);
 void bench_lat_close(char *argv[]);
 
 int run(int argc, char *argv[]) {
     ssize_t rv;
     uint64_t readcount = 0, writecount = 0, iter;
+    uint8_t signal = 0;
 
-    if (argc != 6) {
-        printf("./bench_lat1 [test channel 1] [test channel 2] [sync channel] [message length] [nbytes]\n\n");
+    if (argc != 7) {
+        printf("./bench_lat1 [test channel 1] [test channel 2] [sync channel 1] [sync channel 2] [message length] [nbytes]\n\n");
         return 1;
     }
 
-    if (bench_lat_setup(argv, O_WRONLY, O_RDONLY, O_RDONLY)) {
+    if (bench_lat_setup(argv, O_WRONLY, O_RDONLY, O_WRONLY, O_RDONLY)) {
         return 1;
     }
 
-    if (signal_len > nbytes) {
-        signal_len = nbytes;
-    }
-
-    rv = pirate_read(sync_gd, read_buffer, signal_len);
+    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel initial read error");
+        perror("Sync channel 2 initial read error");
         return 1;
     }
 
-    rv = pirate_write(test_gd1, write_buffer, signal_len);
+    rv = pirate_write(sync_gd1, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Test channel initial write error");
+        perror("Sync channel 1 initial write error");
         return 1;
     }
 
@@ -90,9 +87,9 @@ int run(int argc, char *argv[]) {
         }
     }
 
-    rv = pirate_read(sync_gd, write_buffer, signal_len);
+    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel terminal read error");
+        perror("Sync channel 2 terminal read error");
         return 1;
     }
 

--- a/libpirate/bench/bench_lat2.c
+++ b/libpirate/bench/bench_lat2.c
@@ -15,102 +15,93 @@
 
 #define _GNU_SOURCE
 
-#ifndef MIN
-#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
-#endif
-
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "bench_lat.h"
 
-#include "libpirate.h"
-
-int test_gd1 = -1, test_gd2 = -1, sync_gd1 = -1, sync_gd2 = -1;
-uint64_t nbytes;
-size_t message_len;
-char message[80];
-unsigned char *read_buffer, *write_buffer;
-
-int bench_lat_setup(char *argv[], int test_flag1, int test_flag2, int sync_flag1, int sync_flag2);
-void bench_lat_close(char *argv[]);
-
-int run(int argc, char *argv[]) {
+int run(bench_lat_t *bench) {
     ssize_t rv;
-    uint64_t readcount = 0, writecount = 0, iter, delta;
+    const uint32_t iter = bench->nbytes / bench->message_len;
+    uint64_t delta;
     struct timespec start, stop;
     uint8_t signal = 1;
+    const struct timespec ts = {
+        .tv_sec = bench->tx_delay_ns / 1000000000,
+        .tv_nsec = (bench->tx_delay_ns % 1000000000)
+    };
 
-    if (argc != 7) {
-        printf("./bench_lat1 [test channel 1] [test channel 2] [sync channel 1] [sync channel 2] [message length] [nbytes]\n\n");
-        return 1;
+    /* Open and configure synchronization and test channels */
+    if (bench_lat_setup(bench, O_RDONLY, O_WRONLY, O_RDONLY, O_WRONLY)) {
+        return -1;
     }
 
-    if (bench_lat_setup(argv, O_RDONLY, O_WRONLY, O_RDONLY, O_WRONLY)) {
-        return 1;
-    }
-
-    rv = pirate_write(sync_gd2, &signal, sizeof(signal));
+    rv = pirate_write(bench->sync_ch2.gd, &signal, sizeof(signal));
     if (rv < 0) {
         perror("Sync channel 2 initial write error");
-        return 1;
+        return -1;
     }
 
-    rv = pirate_read(sync_gd1, &signal, sizeof(signal));
+    rv = pirate_read(bench->sync_ch1.gd, &signal, sizeof(signal));
     if (rv < 0) {
         perror("Sync channel 1 initial read error");
-        return 1;
+        return -1;
     }
-
-    iter = nbytes / message_len;
 
     if (clock_gettime(CLOCK_MONOTONIC, &start) < 0) {
-      perror("clock_gettime start");
-      return 1;
+        perror("clock_gettime start");
+        return -1;
     }
-    for (uint64_t i = 0; i < iter; i++) {
-        ssize_t count;
 
-        count = message_len;
+    for (uint64_t i = 0; i < iter; i++) {
+        size_t count;
+
+        count = bench->message_len;
         while (count > 0) {
-            rv = pirate_write(test_gd2, write_buffer + writecount, count);
+            // Sleep must happen before the write
+            // to slow down the write.
+            // If the sleep happens before the read
+            // then we are just replacing some blocking
+            // read time with sleep time.
+            if (bench->tx_delay_ns >= 1000000000) {
+                nanosleep(&ts, NULL);
+            } else if (bench->tx_delay_ns > 0) {
+                bench_lat_busysleep(bench->tx_delay_ns);
+            }
+            rv = pirate_write(bench->test_ch2.gd, bench->write_buffer, count);
             if (rv < 0) {
                 perror("Test channel 2 write error");
-                return 1;
+                return -1;
             }
-            writecount += rv;
             count -= rv;
         }
 
-        count = message_len;
+        count = bench->message_len;
         while (count > 0) {
-            rv = pirate_read(test_gd1, read_buffer + readcount, count);
+            rv = pirate_read(bench->test_ch1.gd, bench->read_buffer, count);
             if (rv < 0) {
-                perror("Test channel 1 read error");
-                return 1;
+                if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                    perror("Test channel 1 read timeout");
+                } else {
+                    perror("Test channel 1 read error");
+                }
+                return -1;
             }
-            readcount += rv;
             count -= rv;
         }
     }
+
     if (clock_gettime(CLOCK_MONOTONIC, &stop) < 0) {
-      perror("clock_gettime stop");
-      return 1;
+        perror("clock_gettime stop");
+        return -1;
     }
 
-    rv = pirate_write(sync_gd1, &signal, sizeof(signal));
+    rv = pirate_write(bench->sync_ch2.gd, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel 1 terminal write error");
-        return 1;
-    }
-
-    for (uint64_t i = 0; i < nbytes; i++) {
-        if (read_buffer[i] != (unsigned char) (i % UCHAR_MAX)) {
-            fprintf(stderr, "At position %zu expected %zu and read character %d\n",
-                i, (i % UCHAR_MAX), (int) read_buffer[i]);
-            return 1;
-        }
+        perror("Sync channel 2 terminating write error");
+        return -1;
     }
 
     delta = ((stop.tv_sec - start.tv_sec) * 1000000000ll +
@@ -122,7 +113,10 @@ int run(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-    int rv = run(argc, argv);
-    bench_lat_close(argv);
+    bench_lat_t bench;
+    memset(&bench, 0, sizeof(bench));
+    parse_args(argc, argv, &bench);
+    int rv = run(&bench);
+    bench_lat_close(&bench);
     return rv;
 }

--- a/libpirate/bench/bench_lat_common.c
+++ b/libpirate/bench/bench_lat_common.c
@@ -15,101 +15,236 @@
 
 #define _GNU_SOURCE
 
-#ifndef MAX
-#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
-#endif
-
-#ifndef MIN
-#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
-#endif
-
 #include <errno.h>
 #include <fcntl.h>
-#include <limits.h>
 #include <netinet/tcp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
-#include "libpirate.h"
+#include "bench_lat.h"
 
-extern int test_gd1, test_gd2, sync_gd1, sync_gd2;
-extern uint64_t nbytes;
-extern size_t message_len;
-extern char message[80];
-extern unsigned char *read_buffer, *write_buffer;
+static struct argp_option options[] = {
+    { "channel1",    'c', "CONFIG", 0, "Test channel 1 configuration",  0 },
+    { "channel2",    'C', "CONFIG", 0, "Test channel 2 configuration",  0 },
+    { "sync1",       's', "CONFIG", 0, "Sync channel 1 configuration",  0 },
+    { "sync2",       'S', "CONFIG", 0, "Sync channel 2 configuration",  0 },
+    { "nbytes",      'n', "BYTES",  0, "Number of bytes to receive",    0 },
+    { "message_len", 'm', "BYTES",  0, "Transfer message size",         0 },
+    { "tx_delay",    'd', "USEC",   0, "Inter-message delay",           0 },
+    { "rx_timeout",  'w', "SEC",    0, "Message receive timeout",       0 },
+    { NULL,           0,  NULL,     0, GAPS_CHANNEL_OPTIONS,            2 },
+    { NULL,           0,  NULL,     0, 0,                               0 }
+};
 
-static int bench_lat_open(int num, char *param_str, pirate_channel_param_t *param, int flags) {
-    int err, fd, rv;
-    size_t bufsize;
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    bench_lat_t *bench = (bench_lat_t *) state->input;
+    char* endptr = NULL;
 
-    bufsize = 8 * message_len;
+    switch (key) {
 
-    switch (param->channel_type) {
+    case 'c':
+        bench->test_ch1.config = arg;
+        break;
+
+    case 'C':
+        bench->test_ch2.config = arg;
+        break;
+
+    case 's':
+        bench->sync_ch1.config = arg;
+        break;
+
+    case 'S':
+        bench->sync_ch2.config = arg;
+        break;
+
+    case 'n':
+        bench->nbytes = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'm':
+        bench->message_len = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'd':
+        bench->tx_delay_ns = (uint64_t) (strtod(arg, &endptr) * 1000.0);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'w':
+        bench->rx_timeout_s = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case ARGP_KEY_END:
+        if (bench->test_ch1.config == NULL) {
+            argp_error(state, "Test channel 1 configuration is not specified");
+        }
+
+        if (bench->test_ch2.config == NULL) {
+            argp_error(state, "Test channel 2 configuration is not specified");
+        }
+
+        if (bench->sync_ch1.config == NULL) {
+            argp_error(state, "Sync channel 1 configuration is not specified");
+        }
+
+        if (bench->sync_ch2.config == NULL) {
+            argp_error(state, "Sync channel 2 configuration is not specified");
+        }
+
+        if (strstr(bench->sync_ch1.config, "tcp_socket,") == NULL) {
+            argp_error(state,"Sync channel 1 '%s' must be a tcp_socket",
+                        bench->sync_ch1.config);
+        }
+
+        if (strstr(bench->sync_ch2.config, "tcp_socket,") == NULL) {
+            argp_error(state,"Sync channel 2 '%s' must be a tcp_socket",
+                        bench->sync_ch2.config);
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+void parse_args(int argc, char *argv[], bench_lat_t *bench) {
+    /* Default parameters */
+    bench->test_ch1.config = NULL;
+    bench->test_ch1.gd     = -1;
+    bench->test_ch2.config = NULL;
+    bench->test_ch2.gd     = -1;
+    bench->sync_ch1.config = NULL;
+    bench->sync_ch1.gd     = -1;
+    bench->sync_ch2.config = NULL;
+    bench->sync_ch2.gd     = -1;
+    bench->nbytes          = 1024;
+    bench->message_len     = 128;
+    bench->tx_delay_ns     = 0;
+    bench->rx_timeout_s    = 2;
+
+    struct argp argp = {
+        .options = options,
+        .parser = parse_opt,
+        .args_doc = NULL,
+        .doc = "PIRATE latency benchmark",
+        .children = NULL,
+        .help_filter = NULL,
+        .argp_domain = NULL
+    };
+
+    argp_parse(&argp, argc, argv, 0, 0, bench);
+}
+
+static int bench_lat_open(bench_lat_t *bench, const char *config, int flags) {
+    pirate_channel_param_t param;
+    size_t bufsize = 8 * bench->message_len;
+    int err, gd, fd;
+
+    if (pirate_parse_channel_param(config, &param)) {
+        fprintf(stderr, "Unable to parse test channel \"%s\"\n",
+            config);
+        return -1;
+    }
+
+    switch (param.channel_type) {
         case SHMEM:
-            if ((bufsize > DEFAULT_SMEM_BUF_LEN) && (param->channel.shmem.buffer_size == 0)) {
-                param->channel.shmem.buffer_size = MIN(bufsize, 524288);
+            if ((bufsize > DEFAULT_SMEM_BUF_LEN) && (param.channel.shmem.buffer_size == 0)) {
+                param.channel.shmem.buffer_size = MIN(bufsize, 524288);
             }
             break;
         case UNIX_SOCKET:
-            if ((bufsize > 212992) && (param->channel.unix_socket.buffer_size == 0)) {
-                param->channel.unix_socket.buffer_size = bufsize;
+            if ((bufsize > 212992) && (param.channel.unix_socket.buffer_size == 0)) {
+                param.channel.unix_socket.buffer_size = bufsize;
             }
             break;
         case UDP_SHMEM:
-            if (param->channel.udp_shmem.packet_size == 0) {
-                param->channel.udp_shmem.packet_size = MAX(message_len, 64);
+            if (param.channel.udp_shmem.packet_size == 0) {
+                param.channel.udp_shmem.packet_size = MAX(bench->message_len, 64);
             }
             break;
         default:
             break;
     }
 
-    rv = pirate_open_param(param, flags);
-    if (rv < 0) {
-        snprintf(message, sizeof(message), "Unable to open test channel %d \"%s\"", num, param_str);
-        perror(message);
-        if (param->channel_type == UNIX_SOCKET) {
+    gd = pirate_open_param(&param, flags);
+    if (gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open test channel \"%s\"",
+                    config);
+        perror(bench->err_msg);
+        if (param.channel_type == UNIX_SOCKET) {
             fprintf(stderr, "Check /proc/sys/net/core/wmem_max\n");
         }
-        return rv;
+        return gd;
     }
+
     err = errno;
-    fd = pirate_get_fd(rv);
+    fd = pirate_get_fd(gd);
     errno = err;
-    switch (param->channel_type) {
+    switch (param.channel_type) {
         case PIPE:
             if (fcntl(fd, F_SETPIPE_SZ, bufsize) < 0) {
-                snprintf(message, sizeof(message),
-                    "Unable to set F_SETPIPE_SZ option on test channel %d \"%s\"",
-                    num, param_str);
-                perror(message);
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to set F_SETPIPE_SZ option on test channel \"%s\"",
+                    config);
+                perror(bench->err_msg);
                 fprintf(stderr, "Check /proc/sys/fs/pipe-max-size\n");
                 return -1;
             }
             break;
+        case UDP_SOCKET:
+        case GE_ETH: {
+            struct timeval tv;
+            tv.tv_sec = bench->rx_timeout_s;
+            tv.tv_usec = 0;
+            if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv,
+                        sizeof(tv)) < 0) {
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to set SO_RCVTIMEO option on test channel \"%s\"",
+                    config);
+                perror(bench->err_msg);
+                return -1;
+            }
+            break;
+        }
         case TCP_SOCKET: {
             struct linger socket_reset;
-            int enable = 1;
             socket_reset.l_onoff = 1;
             socket_reset.l_linger = 0;
+            int enable = 1;
             if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &socket_reset,
                         sizeof(socket_reset)) < 0) {
-                snprintf(message, sizeof(message),
-                    "Unable to set SO_LINGER option on test channel %d \"%s\"",
-                    num, param_str);
-                perror(message);
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to set SO_LINGER option on test channel \"%s\"",
+                    config);
+                perror(bench->err_msg);
                 return -1;
             }
             // TCP_NODELAY is unique to latency tests
             // Do not enable TCP_NODELAY on throughput tests
             if (setsockopt(fd,  IPPROTO_TCP, TCP_NODELAY, &enable,
                         sizeof(enable)) < 0) {
-                snprintf(message, sizeof(message),
-                    "Unable to set TCP_NODELAY option on test channel %d \"%s\"",
-                    num, param_str);
-                perror(message);
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to set TCP_NODELAY option on test channel \"%s\"",
+                    config);
+                perror(bench->err_msg);
                 return -1;
             }
             break;
@@ -117,120 +252,123 @@ static int bench_lat_open(int num, char *param_str, pirate_channel_param_t *para
         default:
             break;
     }
-
-    return rv;
+    return gd;
 }
 
-int bench_lat_setup(char *argv[], int test_flag1, int test_flag2, int sync_flag1, int sync_flag2) {
-    char *endptr;
-    pirate_channel_param_t param1, param2;
-
-    if (strstr(argv[3], "tcp_socket,") == NULL) {
-        fprintf(stderr, "Sync channel 1 \"%s\" must be a tcp socket\n", argv[3]);
-        return 1;
+int bench_lat_setup(bench_lat_t *bench, int test_flags1, int test_flags2, int sync_flags1, int sync_flags2) {
+    /* Open the synchronization channels */
+    bench->sync_ch1.gd = pirate_open_parse(bench->sync_ch1.config, sync_flags1);
+    if (bench->sync_ch1.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open sync channel 1 \"%s\"",
+                    bench->sync_ch1.config);
+        perror(bench->err_msg);
+        return -1;
     }
 
-    if (strstr(argv[4], "tcp_socket,") == NULL) {
-        fprintf(stderr, "Sync channel 2 \"%s\" must be a tcp socket\n", argv[4]);
-        return 1;
+    bench->sync_ch2.gd = pirate_open_parse(bench->sync_ch2.config, sync_flags2);
+    if (bench->sync_ch2.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open sync channel 2 \"%s\"",
+                    bench->sync_ch2.config);
+        perror(bench->err_msg);
+        return -1;
     }
 
-    if (pirate_parse_channel_param(argv[1], &param1)) {
-        fprintf(stderr, "Unable to parse test channel 1 \"%s\"\n", argv[1]);
-        return 1;
+    /* Open the test channels */
+    if ((bench->test_ch1.gd = bench_lat_open(bench, bench->test_ch1.config, test_flags1)) < 0) {
+        return -1;
+    }
+    if ((bench->test_ch2.gd = bench_lat_open(bench, bench->test_ch2.config, test_flags2)) < 0) {
+        return -1;
     }
 
-    if (pirate_parse_channel_param(argv[2], &param2)) {
-        fprintf(stderr, "Unable to parse test channel 2 \"%s\"\n", argv[2]);
-        return 1;
+    /* Truncate nbytes to be divisible by message_len */
+    bench->nbytes = bench->message_len * (bench->nbytes / bench->message_len);
+
+    bench->read_buffer = calloc(bench->message_len, 1);
+    if (bench->read_buffer == NULL) {
+        fprintf(stderr, "Failed to allocate read buffer of %zu bytes\n",
+                    bench->message_len);
+        return -1;
     }
 
-    if (param1.channel_type != param2.channel_type) {
-        fprintf(stderr, "Test channels \"%s\" and \"%s\" are of different type\n", argv[1], argv[2]);
-        return 1;
-    }
-
-    message_len = strtol(argv[5], &endptr, 10);
-    if (*endptr != '\0') {
-        fprintf(stderr, "Unable to parse message length \"%s\"\n", argv[5]);
-        return 1;
-    }
-
-    nbytes = strtol(argv[6], &endptr, 10);
-    if (*endptr != '\0') {
-        snprintf(message, sizeof(message), "Unable to parse number of bytes \"%s\"", argv[6]);
-        perror(message);
-        return 1;
-    }
-
-    test_gd1 = bench_lat_open(1, argv[1], &param1, test_flag1);
-    if (test_gd1 < 0) {
-        return 1;
-    }
-
-    test_gd2 = bench_lat_open(2, argv[2], &param2, test_flag2);
-    if (test_gd2 < 0) {
-        return 1;
-    }
-
-    sync_gd1 = pirate_open_parse(argv[3], sync_flag1);
-    if (sync_gd1 < 0) {
-        snprintf(message, sizeof(message), "Unable to open sync channel 1 \"%s\"", argv[3]);
-        perror(message);
-        return 1;
-    }
-
-    sync_gd2 = pirate_open_parse(argv[4], sync_flag2);
-    if (sync_gd2 < 0) {
-        snprintf(message, sizeof(message), "Unable to open sync channel 2 \"%s\"", argv[4]);
-        perror(message);
-        return 1;
-    }
-
-    // truncate nbytes to be divisible by message_len
-    nbytes = message_len * (nbytes / message_len);
-
-    read_buffer = malloc(nbytes);
-    if (read_buffer == NULL) {
-        fprintf(stderr, "Failed to allocate read_buffer of %zu bytes\n", nbytes);
-        return 1;
-    }
-
-    write_buffer = malloc(nbytes);
-    if (write_buffer == NULL) {
-        fprintf(stderr, "Failed to allocate write_buffer of %zu bytes\n", nbytes);
-        return 1;
-    }
-
-    for (uint64_t i = 0; i < nbytes; i++) {
-        read_buffer[i] = 0;
-        write_buffer[i] = (unsigned char) (i % UCHAR_MAX);
+    bench->write_buffer = calloc(bench->message_len, 1);
+    if (bench->write_buffer == NULL) {
+        fprintf(stderr, "Failed to allocate write buffer of %zu bytes\n",
+                    bench->message_len);
+        return -1;
     }
 
     return 0;
 }
 
-void bench_lat_close(char *argv[]) {
-    if (read_buffer != NULL) {
-        free(read_buffer);
+void bench_lat_close(bench_lat_t *bench) {
+    if (bench->read_buffer != NULL) {
+        free(bench->read_buffer);
+        bench->read_buffer = NULL;
     }
-    if (write_buffer != NULL) {
-        free(write_buffer);
+    if (bench->write_buffer != NULL) {
+        free(bench->write_buffer);
+        bench->write_buffer = NULL;
     }
-    if ((test_gd1 >= 0) && (pirate_close(test_gd1) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close test channel 1 %s", argv[1]);
-        perror(message);
+
+    if ((bench->test_ch1.gd >= 0) && (pirate_close(bench->test_ch1.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close test channel 1 %s", bench->test_ch1.config);
+        perror(bench->err_msg);
     }
-    if ((test_gd2 >= 0) && (pirate_close(test_gd2) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close test channel 2 %s", argv[2]);
-        perror(message);
+
+    if ((bench->test_ch2.gd >= 0) && (pirate_close(bench->test_ch2.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close test channel 2 %s", bench->test_ch2.config);
+        perror(bench->err_msg);
     }
-    if ((sync_gd1 >= 0) && (pirate_close(sync_gd1) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close sync channel 1 %s", argv[3]);
-        perror(message);
+
+    if ((bench->sync_ch1.gd >= 0) && (pirate_close(bench->sync_ch1.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close sync channel 1 %s", bench->sync_ch1.config);
+        perror(bench->err_msg);
     }
-    if ((sync_gd2 >= 0) && (pirate_close(sync_gd2) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close sync channel 2 %s", argv[4]);
-        perror(message);
+
+    if ((bench->sync_ch2.gd >= 0) && (pirate_close(bench->sync_ch2.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close sync channel 2 %s", bench->sync_ch2.config);
+        perror(bench->err_msg);
     }
+}
+
+#define tscmp(a, b, CMP)                             \
+  (((a)->tv_sec == (b)->tv_sec) ?                    \
+   ((a)->tv_nsec CMP (b)->tv_nsec) :                 \
+   ((a)->tv_sec CMP (b)->tv_sec))
+
+#define tsadd(a, b, result)                          \
+  do {                                               \
+    (result)->tv_sec = (a)->tv_sec + (b)->tv_sec;    \
+    (result)->tv_nsec = (a)->tv_nsec + (b)->tv_nsec; \
+    if ((result)->tv_nsec >= 1000000000) {           \
+      ++(result)->tv_sec;                            \
+      (result)->tv_nsec -= 1000000000;               \
+    }                                                \
+  } while (0)
+
+int bench_lat_busysleep(uint32_t nanoseconds) {
+    struct timespec now;
+    struct timespec then;
+    struct timespec start;
+    struct timespec sleep;
+
+    if (nanoseconds >= 1000000000) {
+        return -1;
+    }
+    clock_gettime(CLOCK_MONOTONIC_RAW, &start);
+    now = start;
+    sleep.tv_sec = 0;
+    sleep.tv_nsec = nanoseconds;
+    tsadd(&start, &sleep, &then);
+    while (tscmp(&now, &then, <)) {
+        clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+    }
+    return 0;
 }

--- a/libpirate/bench/bench_thr.h
+++ b/libpirate/bench/bench_thr.h
@@ -1,0 +1,55 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
+ */
+
+#ifndef _PIRATE_BENCH_THR_H
+#define _PIRATE_BENCH_THR_H
+
+#include <argp.h>
+#include <stdint.h>
+#include "libpirate.h"
+
+#ifndef MIN
+#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
+#endif
+
+#ifndef MAX
+#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
+#endif
+
+typedef struct {
+    int gd;
+    const char *config;
+} bench_channel_t;
+
+typedef struct {
+    bench_channel_t test_ch;
+    bench_channel_t sync_ch1;
+    bench_channel_t sync_ch2;
+    uint64_t nbytes;
+    size_t message_len;
+    int validate;
+    uint32_t tx_delay_us;
+    uint32_t rx_timeout_s;
+    uint8_t *buffer;
+    char err_msg[256];
+} bench_thr_t;
+
+void parse_args(int argc, char *argv[], bench_thr_t *bench);
+int bench_sync_write(bench_thr_t *bench, int gd);
+int bench_sync_read(bench_thr_t *bench, int gd);
+int bench_thr_setup(bench_thr_t *bench, int test_flags, int sync_flags1, int sync_flags2);
+void bench_thr_close(bench_thr_t *bench);
+
+#endif /* _PIRATE_BENCH_THR_H */

--- a/libpirate/bench/bench_thr.h
+++ b/libpirate/bench/bench_thr.h
@@ -40,9 +40,10 @@ typedef struct {
     uint64_t nbytes;
     size_t message_len;
     int validate;
-    uint32_t tx_delay_us;
+    uint64_t tx_delay_ns;
     uint32_t rx_timeout_s;
     uint8_t *buffer;
+    uint8_t *bitvector;
     char err_msg[256];
 } bench_thr_t;
 

--- a/libpirate/bench/bench_thr_common.c
+++ b/libpirate/bench/bench_thr_common.c
@@ -32,8 +32,8 @@ static struct argp_option options[] = {
     { "nbytes",      'n', "BYTES",  0, "Number of bytes to receive",    0 },
     { "message_len", 'm', "BYTES",  0, "Transfer message size",         0 },
     { "validate",    'v', NULL,     0, "Validate received data",        0 },
-    { "tx_delay",    'd', "US",     0, "Inter-message delay",           0 },
-    { "rx_timeout",  'w', "S",      0, "Message receive timeout",       0 },
+    { "tx_delay",    'd', "USEC",   0, "Inter-message delay",           0 },
+    { "rx_timeout",  'w', "SEC",    0, "Message receive timeout",       0 },
     { NULL,           0,  NULL,     0, GAPS_CHANNEL_OPTIONS,            2 },
     { NULL,           0,  NULL,     0, 0,                               0 }
 };

--- a/libpirate/bench/bench_thr_common.c
+++ b/libpirate/bench/bench_thr_common.c
@@ -15,14 +15,6 @@
 
 #define _GNU_SOURCE
 
-#ifndef MAX
-#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
-#endif
-
-#ifndef MIN
-#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
-#endif
-
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
@@ -31,59 +23,176 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "libpirate.h"
+#include "bench_thr.h"
 
-extern int test_gd, sync_gd1, sync_gd2;
-extern uint64_t nbytes;
-extern size_t message_len;
-extern char message[80];
-extern unsigned char* buffer;
+static struct argp_option options[] = {
+    { "channel",     'c', "CONFIG", 0, "Test channel configuration",    0 },
+    { "sync1",       's', "CONFIG", 0, "Sync channel 1 configuration",  0 },
+    { "sync2",       'S', "CONFIG", 0, "Sync channel 2 configuration",  0 },
+    { "nbytes",      'n', "BYTES",  0, "Number of bytes to receive",    0 },
+    { "message_len", 'm', "BYTES",  0, "Transfer message size",         0 },
+    { "tx_delay",    'd', "US",     0, "Inter-message delay",           0 },
+    { "rx_timeout",  'w', "S",      0, "Message receive timeout",       0 },
+    { NULL,           0,  NULL,     0, GAPS_CHANNEL_OPTIONS,            2 },
+    { NULL,           0,  NULL,     0, 0,                               0 }
+};
 
-static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int flags) {
-    int err, fd, rv;
-    size_t bufsize;
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+    bench_thr_t *bench = (bench_thr_t *) state->input;
+    char* endptr = NULL;
 
-    bufsize = 8 * message_len;
+    switch (key) {
 
-    switch (param->channel_type) {
+    case 'c':
+        bench->test_ch.config = arg;
+        break;
+
+    case 's':
+        bench->sync_ch1.config = arg;
+        break;
+
+    case 'S':
+        bench->sync_ch2.config = arg;
+        break;
+
+    case 'n':
+        bench->nbytes = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'm':
+        bench->message_len = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'd':
+        bench->tx_delay_us = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case 'w':
+        bench->rx_timeout_s = strtol(arg, &endptr, 10);
+        if (*endptr != '\0') {
+            argp_error(state, "Unable to parse numeric value from \"%s\"\n", arg);
+        }
+        break;
+
+    case ARGP_KEY_END:
+        if (bench->test_ch.config == NULL) {
+            argp_error(state, "Test channel configuration is not specified");
+        }
+
+        if (bench->sync_ch1.config == NULL) {
+            argp_error(state, "Sync channel 1 configuration is not specified");
+        }
+
+        if (bench->sync_ch2.config == NULL) {
+            argp_error(state, "Sync channel 2 configuration is not specified");
+        }
+
+        if (strstr(bench->sync_ch1.config, "tcp_socket,") == NULL) {
+            argp_error(state,"Sync channel 1 '%s' must be a tcp_socket",
+                        bench->sync_ch1.config);
+        }
+
+        if (strstr(bench->sync_ch2.config, "tcp_socket,") == NULL) {
+            argp_error(state,"Sync channel 2 '%s' must be a tcp_socket",
+                        bench->sync_ch2.config);
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+void parse_args(int argc, char *argv[], bench_thr_t *bench) {
+    /* Default parameters */
+    bench->test_ch.config  = NULL;
+    bench->test_ch.gd      = -1;
+    bench->sync_ch1.config = NULL;
+    bench->sync_ch1.gd     = -1;
+    bench->sync_ch2.config = NULL;
+    bench->sync_ch2.gd     = -1;
+    bench->nbytes          = 1024;
+    bench->message_len     = 128;
+    bench->tx_delay_us     = 0;
+    bench->rx_timeout_s    = 2;
+
+    struct argp argp = {
+        .options = options,
+        .parser = parse_opt,
+        .args_doc = NULL,
+        .doc = "PIRATE throughput benchmark",
+        .children = NULL,
+        .help_filter = NULL,
+        .argp_domain = NULL
+    };
+
+    argp_parse(&argp, argc, argv, 0, 0, bench);
+}
+
+static int bench_thr_open(bench_thr_t *bench, int flags) {
+    pirate_channel_param_t param;
+    size_t bufsize = 8 * bench->message_len;
+    int err, fd;
+
+    if (pirate_parse_channel_param(bench->test_ch.config, &param)) {
+        fprintf(stderr, "Unable to parse test channel \"%s\"\n",
+            bench->test_ch.config);
+        return -1;
+    }
+
+    switch (param.channel_type) {
         case SHMEM:
-            if ((bufsize > DEFAULT_SMEM_BUF_LEN) && (param->channel.shmem.buffer_size == 0)) {
-                param->channel.shmem.buffer_size = MIN(bufsize, 524288);
+            if ((bufsize > DEFAULT_SMEM_BUF_LEN) && (param.channel.shmem.buffer_size == 0)) {
+                param.channel.shmem.buffer_size = MIN(bufsize, 524288);
             }
             break;
         case UNIX_SOCKET:
-            if ((bufsize > 212992) && (param->channel.unix_socket.buffer_size == 0)) {
-                param->channel.unix_socket.buffer_size = bufsize;
+            if ((bufsize > 212992) && (param.channel.unix_socket.buffer_size == 0)) {
+                param.channel.unix_socket.buffer_size = bufsize;
             }
             break;
         case UDP_SHMEM:
-            if (param->channel.udp_shmem.packet_size == 0) {
-                param->channel.udp_shmem.packet_size = MAX(message_len, 64);
+            if (param.channel.udp_shmem.packet_size == 0) {
+                param.channel.udp_shmem.packet_size = MAX(bench->message_len, 64);
             }
             break;
         default:
             break;
     }
 
-    rv = pirate_open_param(param, flags);
-    if (rv < 0) {
-        snprintf(message, sizeof(message), "Unable to open test channel \"%s\"", param_str);
-        perror(message);
-        if (param->channel_type == UNIX_SOCKET) {
+    bench->test_ch.gd = pirate_open_param(&param, flags);
+    if (bench->test_ch.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open test channel \"%s\"",
+                    bench->test_ch.config);
+        perror(bench->err_msg);
+        if (param.channel_type == UNIX_SOCKET) {
             fprintf(stderr, "Check /proc/sys/net/core/wmem_max\n");
         }
-        return rv;
+        return bench->test_ch.gd;
     }
+
     err = errno;
-    fd = pirate_get_fd(rv);
+    fd = pirate_get_fd(bench->test_ch.gd);
     errno = err;
-    switch (param->channel_type) {
+    switch (param.channel_type) {
         case PIPE:
             if (fcntl(fd, F_SETPIPE_SZ, bufsize) < 0) {
-                snprintf(message, sizeof(message),
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
                     "Unable to set F_SETPIPE_SZ option on test channel \"%s\"",
-                    param_str);
-                perror(message);
+                    bench->test_ch.config);
+                perror(bench->err_msg);
                 fprintf(stderr, "Check /proc/sys/fs/pipe-max-size\n");
                 return -1;
             }
@@ -91,14 +200,14 @@ static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int fl
         case UDP_SOCKET:
         case GE_ETH: {
             struct timeval tv;
-            tv.tv_sec = 2;
+            tv.tv_sec = bench->rx_timeout_s;
             tv.tv_usec = 0;
             if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv,
                         sizeof(tv)) < 0) {
-                snprintf(message, sizeof(message),
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
                     "Unable to set SO_RCVTIMEO option on test channel \"%s\"",
-                    param_str);
-                perror(message);
+                    bench->test_ch.config);
+                perror(bench->err_msg);
                 return -1;
             }
             break;
@@ -109,10 +218,10 @@ static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int fl
             socket_reset.l_linger = 0;
             if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &socket_reset,
                         sizeof(socket_reset)) < 0) {
-                snprintf(message, sizeof(message),
+                snprintf(bench->err_msg, sizeof(bench->err_msg),
                     "Unable to set SO_LINGER option on test channel \"%s\"",
-                    param_str);
-                perror(message);
+                    bench->test_ch.config);
+                perror(bench->err_msg);
                 return -1;
             }
             break;
@@ -120,87 +229,68 @@ static int bench_thr_open(char *param_str, pirate_channel_param_t *param, int fl
         default:
             break;
     }
-
-    return rv;
+    return 0;
 }
 
-int bench_thr_setup(char *argv[], int test_flags, int sync_flag1, int sync_flag2) {
-    char* endptr;
-    pirate_channel_param_t param;
-
-    if (strstr(argv[2], "tcp_socket,") == NULL) {
-        fprintf(stderr, "Sync channel 1 %s must be a tcp socket\n", argv[2]);
-        return 1;
+int bench_thr_setup(bench_thr_t *bench, int test_flags, int sync_flags1, int sync_flags2) {
+    /* Open the synchronization channels */
+    bench->sync_ch1.gd = pirate_open_parse(bench->sync_ch1.config, sync_flags1);
+    if (bench->sync_ch1.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open sync channel 1 \"%s\"",
+                    bench->sync_ch1.config);
+        perror(bench->err_msg);
+        return -1;
     }
 
-    if (strstr(argv[3], "tcp_socket,") == NULL) {
-        fprintf(stderr, "Sync channel 2 %s must be a tcp socket\n", argv[3]);
-        return 1;
+    bench->sync_ch2.gd = pirate_open_parse(bench->sync_ch2.config, sync_flags2);
+    if (bench->sync_ch2.gd < 0) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to open sync channel 2 \"%s\"",
+                    bench->sync_ch2.config);
+        perror(bench->err_msg);
+        return -1;
     }
 
-    if (pirate_parse_channel_param(argv[1], &param)) {
-        fprintf(stderr, "Unable to parse test channel \"%s\"\n", argv[1]);
-        return 1;
+    /* Open the test channel */
+    if (bench_thr_open(bench, test_flags) != 0) {
+        return -1;
     }
 
-    sync_gd1 = pirate_open_parse(argv[2], sync_flag1);
-    if (sync_gd1 < 0) {
-        snprintf(message, sizeof(message), "Unable to open sync channel 1 \"%s\"", argv[2]);
-        perror(message);
-        return 1;
-    }
+    /* Truncate nbytes to be divisible by message_len */
+    bench->nbytes = bench->message_len * (bench->nbytes / bench->message_len);
 
-    sync_gd2 = pirate_open_parse(argv[3], sync_flag2);
-    if (sync_gd2 < 0) {
-        snprintf(message, sizeof(message), "Unable to open sync channel 2 \"%s\"", argv[3]);
-        perror(message);
-        return 1;
-    }
-
-    message_len = strtol(argv[4], &endptr, 10);
-    if (*endptr != '\0') {
-        fprintf(stderr, "Unable to parse message length \"%s\"\n", argv[4]);
-        return 1;
-    }
-
-    nbytes = strtol(argv[5], &endptr, 10);
-    if (*endptr != '\0') {
-        snprintf(message, sizeof(message), "Unable to parse number of bytes \"%s\"", argv[5]);
-        perror(message);
-        return 1;
-    }
-
-    // truncate nbytes to be divisible by message_len
-    nbytes = message_len * (nbytes / message_len);
-
-    test_gd = bench_thr_open(argv[1], &param, test_flags);
-    if (test_gd < 0) {
-        return 1;
-    }
-
-    buffer = malloc(nbytes);
-    if (buffer == NULL) {
-        fprintf(stderr, "Failed to allocate buffer of %zu bytes\n", nbytes);
-        return 1;
+    bench->buffer = calloc(bench->nbytes, 1);
+    if (bench->buffer == NULL) {
+        fprintf(stderr, "Failed to allocate buffer of %zu bytes\n",
+                    bench->nbytes);
+        return -1;
     }
 
     return 0;
 }
 
-void bench_thr_close(char *argv[]) {
-    if (buffer != NULL) {
-        free(buffer);
+void bench_thr_close(bench_thr_t *bench) {
+    if (bench->buffer != NULL) {
+        free(bench->buffer);
+        bench->buffer = NULL;
     }
-    if ((test_gd >= 0) && (pirate_close(test_gd) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close test channel %s", argv[1]);
-        perror(message);
+
+    if ((bench->test_ch.gd >= 0) && (pirate_close(bench->test_ch.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close test channel %s", bench->test_ch.config);
+        perror(bench->err_msg);
     }
-    if ((sync_gd1 >= 0) && (pirate_close(sync_gd1) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close sync channel 1 %s", argv[2]);
-        perror(message);
+
+    if ((bench->sync_ch1.gd >= 0) && (pirate_close(bench->sync_ch1.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close sync channel 1 %s", bench->sync_ch1.config);
+        perror(bench->err_msg);
     }
-    if ((sync_gd2 >= 0) && (pirate_close(sync_gd2) < 0)) {
-        snprintf(message, sizeof(message), "Unable to close sync channel 2 %s", argv[3]);
-        perror(message);
+
+    if ((bench->sync_ch2.gd >= 0) && (pirate_close(bench->sync_ch2.gd) < 0)) {
+        snprintf(bench->err_msg, sizeof(bench->err_msg),
+                    "Unable to close sync channel 2 %s", bench->sync_ch2.config);
+        perror(bench->err_msg);
     }
 }

--- a/libpirate/bench/bench_thr_common.c
+++ b/libpirate/bench/bench_thr_common.c
@@ -70,7 +70,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
         }
         break;
 
-   case 'v':
+    case 'v':
         bench->validate = 1;
         break;
 

--- a/libpirate/bench/bench_thr_reader.c
+++ b/libpirate/bench/bench_thr_reader.c
@@ -19,6 +19,7 @@
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 #endif
 
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -27,58 +28,62 @@
 
 #include "libpirate.h"
 
-int test_gd = -1, sync_gd = -1;
+int test_gd = -1, sync_gd1 = -1, sync_gd2 = -1;
 uint64_t nbytes;
-size_t message_len, signal_len = 64;
+size_t message_len;
 char message[80];
 unsigned char* buffer;
 
-int bench_thr_setup(char *argv[], int test_flags, int sync_flags);
+int bench_thr_setup(char *argv[], int test_flags, int sync_flag1, int sync_flag2);
 void bench_thr_close(char *argv[]);
 
 int run(int argc, char *argv[]) {
     ssize_t rv;
     uint64_t readcount = 0, iter, delta;
     struct timespec start, stop;
+    int timeout = 0;
+    uint8_t signal = 1;
 
-    if (argc != 5) {
-        printf("./bench_thr_reader [test channel] [sync channel] [message length] [nbytes]\n\n");
+    if (argc != 6) {
+        printf("./bench_thr_reader [test channel] [sync channel 1] [sync channel 2] [message length] [nbytes]\n\n");
         return 1;
     }
 
-    if (bench_thr_setup(argv, O_RDONLY, O_WRONLY)) {
+    if (bench_thr_setup(argv, O_RDONLY, O_RDONLY, O_WRONLY)) {
         return 1;
-    }
-
-    if (signal_len > nbytes) {
-        signal_len = nbytes;
     }
 
     memset(buffer, 0, nbytes);
 
-    rv = pirate_write(sync_gd, buffer, signal_len);
+    rv = pirate_write(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel initial write error");
+        perror("Sync channel 2 initial write error");
         return 1;
     }
 
-    rv = pirate_read(test_gd, buffer, signal_len);
+    rv = pirate_read(sync_gd1, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Test channel initial read error");
+        perror("Sync channel 1 initial read error");
         return 1;
     }
+
     iter = nbytes / message_len;
     if (clock_gettime(CLOCK_MONOTONIC, &start) < 0) {
       perror("clock_gettime start");
       return 1;
     }
-    for (uint64_t i = 0; i < iter; i++) {
+    for (uint64_t i = 0; i < iter && !timeout; i++) {
         size_t count;
 
         count = message_len;
         while (count > 0) {
             rv = pirate_read(test_gd, buffer + readcount, count);
             if (rv < 0) {
+                if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                    errno = 0;
+                    timeout = 1;
+                    break;
+                }
                 perror("Test channel read error");
                 return 1;
             }
@@ -91,25 +96,33 @@ int run(int argc, char *argv[]) {
       return 1;
     }
 
-    rv = pirate_write(sync_gd, buffer, signal_len);
+    rv = pirate_write(sync_gd2, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel terminating write error");
+        perror("Sync channel 2 terminating write error");
         return 1;
     }
 
-    for (uint64_t i = 0; i < nbytes; i++) {
-        if (buffer[i] != (unsigned char) (i % UCHAR_MAX)) {
-            fprintf(stderr, "At position %zu expected %zu and read character %d\n",
-                i, (i % UCHAR_MAX), (int) buffer[i]);
-            break;
+    for (uint64_t i = 0; i < iter; i++) {
+        for (uint64_t j = 0; j < message_len && (i * message_len + j) < readcount; j++) {
+            if (buffer[i * message_len + j] != (unsigned char) (j & 0xFF)) {
+                fprintf(stderr, "At position %zu of packet %zu expected %zu and read character %d\n",
+                j, i, (j & 0xFF), (int) buffer[i * message_len + j]);
+            }
         }
     }
+
     delta = ((stop.tv_sec - start.tv_sec) * 1000000000ll +
              (stop.tv_nsec - start.tv_nsec));
+    if (timeout) {
+        // subtract timeout wait
+        delta -= 2 * 1000000000ll;
+    }
     // 1e9 nanoseconds per second
     // 1e6 bytes per megabytes
     printf("average throughput: %f MB/s\n",
-           ((1e9 / 1e6) * nbytes) / delta);
+           ((1e9 / 1e6) * readcount) / delta);
+    printf("drop rate: %f %%\n",
+        ((nbytes - readcount) / (nbytes * 1.0)) * 100.0);
 
     return 0;
 }

--- a/libpirate/bench/bench_thr_writer.c
+++ b/libpirate/bench/bench_thr_writer.c
@@ -53,7 +53,7 @@ int busysleep(uint32_t nanoseconds)
     sleep.tv_nsec = nanoseconds;
     tsadd(&start, &sleep, &then);
     while (tscmp(&now, &then, <)) {
-        clock_gettime( CLOCK_MONOTONIC_RAW, &now);
+        clock_gettime(CLOCK_MONOTONIC_RAW, &now);
     }
     return 0;
 }

--- a/libpirate/bench/bench_thr_writer.c
+++ b/libpirate/bench/bench_thr_writer.c
@@ -13,86 +13,83 @@
  * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
  */
 
-#ifndef MIN
-#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
-#endif
-
+#include <time.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "bench_thr.h"
 
-#include "libpirate.h"
-
-int test_gd = -1, sync_gd1 = -1, sync_gd2 = -1;
-uint64_t nbytes;
-size_t message_len;
-char message[80];
-unsigned char* buffer;
-
-int bench_thr_setup(char *argv[], int test_flags, int sync_flag1, int sync_flag2);
-void bench_thr_close(char *argv[]);
-
-int run(int argc, char *argv[]) {
+int run(bench_thr_t *bench) {
     ssize_t rv;
-    uint64_t writecount = 0, iter;
-    uint8_t signal = 0;
+    const uint64_t iter = bench->nbytes / bench->message_len;
+    uint64_t write_off = 0;
+    uint8_t signal = 1;
 
-    if (argc != 6) {
-        printf("./bench_thr_writer [test channel] [sync channel 1] [sync channel 2] [message length] [nbytes]\n\n");
-        return 1;
+    const struct timespec ts = {
+        .tv_sec = bench->tx_delay_us / 1000000,
+        .tv_nsec = (bench->tx_delay_us % 1000000) * 1000
+    };
+
+    /* Open and configure synchronization and test channels */
+    if (bench_thr_setup(bench, O_WRONLY, O_WRONLY, O_RDONLY)) {
+        return -1;
     }
 
-    if (bench_thr_setup(argv, O_WRONLY, O_WRONLY, O_RDONLY)) {
-        return 1;
-    }
-
-    iter = nbytes / message_len;
-
+    /* Initialize the write buffer */
     for (uint64_t i = 0; i < iter; i++) {
-        for (uint64_t j = 0; j < message_len; j++) {
-            buffer[i * message_len + j] = (unsigned char)(j & 0xFF);
+        for (uint64_t j = 0; j < bench->message_len; j++) {
+            uint64_t pos = i * bench->message_len + j;
+            bench->buffer[pos] = (unsigned char)(j & 0xFF);
         }
     }
 
-    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
+    rv = pirate_read(bench->sync_ch2.gd, &signal, sizeof(signal));
     if (rv < 0) {
         perror("Sync channel 2 initial read error");
-        return 1;
+        return -1;
     }
 
-    rv = pirate_write(sync_gd1, &signal, sizeof(signal));
+    rv = pirate_write(bench->sync_ch1.gd, &signal, sizeof(signal));
     if (rv < 0) {
         perror("Sync channel 1 initial write error");
-        return 1;
+        return -1;
     }
 
     for (uint64_t i = 0; i < iter; i++) {
-        size_t count;
-
-        count = message_len;
+        size_t count = bench->message_len;
         while (count > 0) {
-            rv = pirate_write(test_gd, buffer + writecount, count);
+            rv = pirate_write(bench->test_ch.gd, bench->buffer + write_off, count);
             if (rv < 0) {
                 perror("Test channel write error");
-                return 1;
+                return -1;
             }
-            writecount += rv;
+            write_off += rv;
             count -= rv;
+            if (bench->tx_delay_us != 0) {
+                nanosleep(&ts, NULL);
+            }
         }
     }
 
-    rv = pirate_read(sync_gd2, &signal, sizeof(signal));
+    /* Read sync from the reader */
+    rv = pirate_read(bench->sync_ch2.gd, &signal, sizeof(signal));
     if (rv < 0) {
-        perror("Sync channel terminating read error");
-        return 1;
+        perror("Sync channel 2 terminating read error");
+        return -1;
     }
 
     return 0;
 }
 
 int main(int argc, char *argv[]) {
-    int rv = run(argc, argv);
-    bench_thr_close(argv);
+    bench_thr_t bench;
+    memset(&bench, 0, sizeof(bench));
+    parse_args(argc, argv, &bench);
+    int rv = run(&bench);
+    bench_thr_close(&bench);
     return rv;
 }
+
+
+


### PR DESCRIPTION
Cleanup to the benchmarks and channel demo:

- backport the busysleep() into the channel demo. The timestamps printed in the channel demo (with -v) show that the write delays are more precise than using nanosleep().
- refactor the latency benchmark to use the command-line argument parsing
- removed the data validation from the latency benchmark. If we need it then I can add it again. The latency benchmark only sends one packet at a time. If a packet is dropped, then the latency demo will gracefully exit (unlike the throughput demo which reports a dropped packet and continues).
- added README to benchmarks
- better error handling in bench.py