### PR TITLE
Create common_ctx with flags and fd

### DIFF
--- a/libpirate/device.c
+++ b/libpirate/device.c
@@ -60,12 +60,12 @@ int pirate_device_get_channel_description(const pirate_device_param_t *param, ch
     return snprintf(desc, len - 1, "device,%s,iov_len=%u", param->path, param->iov_len);
 }
 
-int pirate_device_open(int flags, pirate_device_param_t *param, device_ctx *ctx) {
+int pirate_device_open(pirate_device_param_t *param, device_ctx *ctx) {
     if (strnlen(param->path, 1) == 0) {
         errno = EINVAL;
         return -1;
     }
-    if ((ctx->fd = open(param->path, flags)) < 0) {
+    if ((ctx->fd = open(param->path, ctx->flags)) < 0) {
         return -1;
     }
     

--- a/libpirate/device.h
+++ b/libpirate/device.h
@@ -20,12 +20,13 @@
 #include "libpirate.h"
 
 typedef struct {
+    int flags;
     int fd;
 } device_ctx;
 
 int pirate_device_parse_param(char *str, pirate_device_param_t *param);
 int pirate_device_get_channel_description(const pirate_device_param_t *param, char *desc, int len);
-int pirate_device_open(int flags, pirate_device_param_t *param, device_ctx *ctx);
+int pirate_device_open(pirate_device_param_t *param, device_ctx *ctx);
 int pirate_device_close(device_ctx *ctx);
 ssize_t pirate_device_read(const pirate_device_param_t *param, device_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_device_write(const pirate_device_param_t *param, device_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -248,9 +248,9 @@ static int ge_eth_writer_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     return 0;
 }
 
-int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
+int pirate_ge_eth_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx) {
     int rv = -1;
-    int access = flags & O_ACCMODE;
+    int access = ctx->flags & O_ACCMODE;
 
     pirate_ge_eth_init_param(param);
     if (param->port <= 0) {

--- a/libpirate/ge_eth.h
+++ b/libpirate/ge_eth.h
@@ -19,13 +19,14 @@
 #include "libpirate.h"
 
 typedef struct {
+    int flags;
     int sock;
     uint8_t *buf;
 } ge_eth_ctx;
 
 int pirate_ge_eth_parse_param(char *str, pirate_ge_eth_param_t *param);
 int pirate_ge_eth_get_channel_description(const pirate_ge_eth_param_t *param, char *desc, int len);
-int pirate_ge_eth_open(int flags, pirate_ge_eth_param_t *param, ge_eth_ctx *ctx);
+int pirate_ge_eth_open(pirate_ge_eth_param_t *param, ge_eth_ctx *ctx);
 int pirate_ge_eth_close(ge_eth_ctx *ctx);
 ssize_t pirate_ge_eth_read(const pirate_ge_eth_param_t *param, ge_eth_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_ge_eth_write(const pirate_ge_eth_param_t *param, ge_eth_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/ge_eth.h
+++ b/libpirate/ge_eth.h
@@ -20,6 +20,7 @@
 
 typedef struct {
     int flags;
+    // TODO move buf before sock
     int sock;
     uint8_t *buf;
 } ge_eth_ctx;

--- a/libpirate/ge_eth.h
+++ b/libpirate/ge_eth.h
@@ -20,7 +20,6 @@
 
 typedef struct {
     int flags;
-    // TODO move buf before sock
     int sock;
     uint8_t *buf;
 } ge_eth_ctx;

--- a/libpirate/libpirate.h
+++ b/libpirate/libpirate.h
@@ -331,17 +331,6 @@ int pirate_unparse_channel_param(const pirate_channel_param_t *param, char *str,
 
 int pirate_get_channel_param(int gd, pirate_channel_param_t *param);
 
-// Returns the open() flags associated with the gaps channel
-//
-// Parameters
-//  gd           - GAPS channel number
-//
-// Return:
-//  non-negative value on success
-// -1 on failure, errno is set
-
-int pirate_get_channel_flags(int gd);
-
 // Get channel parameters as a string
 //
 // Parameters

--- a/libpirate/libpirate_internal.h
+++ b/libpirate/libpirate_internal.h
@@ -22,10 +22,6 @@ extern "C" {
 
 void pirate_reset_gd();
 
-pirate_channel_param_t *pirate_get_channel_param_ref(int gd);
-
-int pirate_enclave_cmpfunc(const void *a, const void *b);
-
 #ifdef __cplusplus
 }
 #endif

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -304,12 +304,11 @@ int pirate_mercury_get_channel_description(const pirate_mercury_param_t *param, 
     return ret_sz;
 }
 
-int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *ctx) {
+int pirate_mercury_open(pirate_mercury_param_t *param, mercury_ctx *ctx) {
     const uint32_t cfg_len = sizeof(uint32_t);
     ssize_t sz;
     int fd_root = -1;
     unsigned wait_counter = 0;
-    ctx->flags = flags;
     int access = ctx->flags & O_ACCMODE;
     const mode_t mode = access == O_RDONLY ? S_IRUSR : S_IWUSR;
 

--- a/libpirate/mercury.h
+++ b/libpirate/mercury.h
@@ -20,6 +20,7 @@
 
 typedef struct {
     int flags;
+    // TODO move buf before fd
     int fd;
     uint8_t *buf;
     char path[PIRATE_LEN_NAME];

--- a/libpirate/mercury.h
+++ b/libpirate/mercury.h
@@ -20,7 +20,6 @@
 
 typedef struct {
     int flags;
-    // TODO move buf before fd
     int fd;
     uint8_t *buf;
     char path[PIRATE_LEN_NAME];

--- a/libpirate/mercury.h
+++ b/libpirate/mercury.h
@@ -19,15 +19,15 @@
 #include "libpirate.h"
 
 typedef struct {
-    int fd;
     int flags;
+    int fd;
     uint8_t *buf;
     char path[PIRATE_LEN_NAME];
 } mercury_ctx;
 
 int pirate_mercury_parse_param(char *str, pirate_mercury_param_t *param);
 int pirate_mercury_get_channel_description(const pirate_mercury_param_t *param, char *desc, int len);
-int pirate_mercury_open(int flags, pirate_mercury_param_t *param, mercury_ctx *ctx);
+int pirate_mercury_open(pirate_mercury_param_t *param, mercury_ctx *ctx);
 int pirate_mercury_close(mercury_ctx *ctx);
 ssize_t pirate_mercury_read(const pirate_mercury_param_t *param, mercury_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_mercury_write(const pirate_mercury_param_t *param, mercury_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/pipe.c
+++ b/libpirate/pipe.c
@@ -60,7 +60,7 @@ int pirate_pipe_get_channel_description(const pirate_pipe_param_t *param, char *
     return snprintf(desc, len - 1, "pipe,%s,iov_len=%u", param->path, param->iov_len);
 }
 
-int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx) {
+int pirate_pipe_open(pirate_pipe_param_t *param, pipe_ctx *ctx) {
     int err;
 
     if (strnlen(param->path, 1) == 0) {
@@ -76,15 +76,14 @@ int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx) {
         }
     }
 
-    if ((ctx->fd = open(param->path, flags)) < 0) {
+    if ((ctx->fd = open(param->path, ctx->flags)) < 0) {
         return -1;
     }
 
     return 0;
 }
 
-int pirate_pipe_pipe(int flags, pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx) {
-    (void) flags;
+int pirate_pipe_pipe(pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx) {
     (void) param;
     int rv, fd[2];
 

--- a/libpirate/pipe.h
+++ b/libpirate/pipe.h
@@ -20,13 +20,14 @@
 #include "libpirate.h"
 
 typedef struct {
+    int flags;
     int fd;
  } pipe_ctx;
 
 int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param);
 int pirate_pipe_get_channel_description(const pirate_pipe_param_t *param, char *desc, int len);
-int pirate_pipe_pipe(int flags, pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx);
-int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx);
+int pirate_pipe_pipe(pirate_pipe_param_t *param, pipe_ctx *read_ctx, pipe_ctx *write_ctx);
+int pirate_pipe_open(pirate_pipe_param_t *param, pipe_ctx *ctx);
 int pirate_pipe_close(pipe_ctx *ctx);
 ssize_t pirate_pipe_read(const pirate_pipe_param_t *param, pipe_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_pipe_write(const pirate_pipe_param_t *param, pipe_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/pirate_common.h
+++ b/libpirate/pirate_common.h
@@ -16,15 +16,36 @@
 #ifndef __PIRATE_COMMON_H
 #define __PIRATE_COMMON_H
 
+#include "libpirate.h"
+
 #include <sys/types.h>
 
 #ifndef MIN
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int flags;
+    // TODO uint8_t *buf;
+    int fd; // fd does not exist on all channel types
+} common_ctx;
+
+pirate_channel_param_t *pirate_get_channel_param_ref(int gd);
+common_ctx *pirate_get_common_ctx_ref(int gd);
+
+int pirate_enclave_cmpfunc(const void *a, const void *b);
+
 ssize_t pirate_fd_read(int fd, void *buf, size_t count, size_t iov_len);
 ssize_t pirate_fd_write(int fd, const void *buf, size_t count, size_t iov_len);
 int pirate_parse_is_common_key(const char *key);
 int pirate_parse_key_value(char **key, char **val, char *ptr, char **saveptr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __PIRATE_COMMON_H */

--- a/libpirate/pirate_common.h
+++ b/libpirate/pirate_common.h
@@ -30,8 +30,8 @@ extern "C" {
 
 typedef struct {
     int flags;
-    // TODO uint8_t *buf;
-    int fd; // fd does not exist on all channel types
+    // fd does not exist on all channel types
+    int fd;
 } common_ctx;
 
 pirate_channel_param_t *pirate_get_channel_param_ref(int gd);

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -53,12 +53,6 @@ typedef int pirate_atomic_int;
 #include "pirate_common.h"
 
 typedef struct {
-    int flags;
-    // TODO uint8_t *buf;
-    int fd; // fd does not exist on all channel types
-} common_ctx;
-
-typedef struct {
     union {
         common_ctx         common;
         device_ctx         device;
@@ -273,15 +267,6 @@ int pirate_get_channel_param(int gd, pirate_channel_param_t *param) {
     return 0;
 }
 
-int pirate_get_channel_flags(int gd) {
-    pirate_channel_t *channel = NULL;
-
-    if ((channel = pirate_get_channel(gd)) == NULL) {
-        return -1;
-    }
-    return channel->ctx.channel.common.flags;
-}
-
 pirate_channel_param_t *pirate_get_channel_param_ref(int gd) {
     pirate_channel_t *channel = NULL;
 
@@ -290,6 +275,16 @@ pirate_channel_param_t *pirate_get_channel_param_ref(int gd) {
     }
 
     return &channel->param;
+}
+
+common_ctx *pirate_get_common_ctx_ref(int gd) {
+    pirate_channel_t *channel = NULL;
+
+    if ((channel = pirate_get_channel(gd)) == NULL) {
+        return NULL;
+    }
+
+    return &channel->ctx.channel.common;
 }
 
 int pirate_unparse_channel_param(const pirate_channel_param_t *param, char *desc, int len) {

--- a/libpirate/primitives.c
+++ b/libpirate/primitives.c
@@ -54,8 +54,8 @@ typedef int pirate_atomic_int;
 
 typedef struct {
     int flags;
-    int fd;
     // TODO uint8_t *buf;
+    int fd; // fd does not exist on all channel types
 } common_ctx;
 
 typedef struct {

--- a/libpirate/serial.c
+++ b/libpirate/serial.c
@@ -109,7 +109,7 @@ int pirate_serial_get_channel_description(const pirate_serial_param_t *param, ch
                     param->mtu);
 }
 
-int pirate_serial_open(int flags, pirate_serial_param_t *param, serial_ctx *ctx) {
+int pirate_serial_open(pirate_serial_param_t *param, serial_ctx *ctx) {
     struct termios attr;
 
     pirate_serial_init_param(param);
@@ -117,7 +117,7 @@ int pirate_serial_open(int flags, pirate_serial_param_t *param, serial_ctx *ctx)
         errno = EINVAL;
         return -1;
     }
-    ctx->fd = open(param->path, flags | O_NOCTTY);
+    ctx->fd = open(param->path, ctx->flags | O_NOCTTY);
     if (ctx->fd < 0) {
         return -1;
     }

--- a/libpirate/serial.h
+++ b/libpirate/serial.h
@@ -19,12 +19,13 @@
 #include "libpirate.h"
 
 typedef struct {
+    int flags;
     int fd;
 } serial_ctx;
 
 int pirate_serial_parse_param(char *str, pirate_serial_param_t *param);
 int pirate_serial_get_channel_description(const pirate_serial_param_t *param, char *desc, int len);
-int pirate_serial_open(int flags, pirate_serial_param_t *param, serial_ctx *ctx);
+int pirate_serial_open(pirate_serial_param_t *param, serial_ctx *ctx);
 int pirate_serial_close(serial_ctx *ctx);
 ssize_t pirate_serial_read(const pirate_serial_param_t *param, serial_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_serial_write(const pirate_serial_param_t *param, serial_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/shmem.c
+++ b/libpirate/shmem.c
@@ -220,11 +220,11 @@ int shmem_buffer_get_channel_description(const pirate_shmem_param_t *param, char
                     param->buffer_size);
 }
 
-int shmem_buffer_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx) {
+int shmem_buffer_open(pirate_shmem_param_t *param, shmem_ctx *ctx) {
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
-    int access = flags & O_ACCMODE;
+    int access = ctx->flags & O_ACCMODE;
 
     shmem_buffer_init_param(param);
     // on successful shm_open (fd > 0) we must shm_unlink before exiting
@@ -283,7 +283,6 @@ int shmem_buffer_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx) {
         }
     }
 
-    ctx->flags = flags;
     return 0;
 error:
     err = errno;

--- a/libpirate/shmem.h
+++ b/libpirate/shmem.h
@@ -20,7 +20,7 @@
 
 int shmem_buffer_parse_param(char *str, pirate_shmem_param_t *param);
 int shmem_buffer_get_channel_description(const pirate_shmem_param_t *param, char *desc, int len);
-int shmem_buffer_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx);
+int shmem_buffer_open(pirate_shmem_param_t *param, shmem_ctx *ctx);
 int shmem_buffer_close(shmem_ctx *ctx);
 ssize_t shmem_buffer_read(const pirate_shmem_param_t *param, shmem_ctx *ctx, void *buf, size_t count);
 ssize_t shmem_buffer_write(const pirate_shmem_param_t *param, shmem_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/shmem_interface.c
+++ b/libpirate/shmem_interface.c
@@ -38,11 +38,11 @@ int pirate_shmem_get_channel_description(const pirate_shmem_param_t *param, char
 #endif
 }
 
-int pirate_shmem_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx) {
+int pirate_shmem_open(pirate_shmem_param_t *param, shmem_ctx *ctx) {
 #ifdef PIRATE_SHMEM_FEATURE
-    return shmem_buffer_open(flags, param, ctx);
+    return shmem_buffer_open(param, ctx);
 #else
-    (void) flags, (void) param, (void) ctx;
+    (void) param, (void) ctx;
     errno = ESOCKTNOSUPPORT;
     return -1;
 #endif

--- a/libpirate/shmem_interface.h
+++ b/libpirate/shmem_interface.h
@@ -26,7 +26,7 @@ typedef struct {
 
 int pirate_shmem_parse_param(char *str, pirate_shmem_param_t *param);
 int pirate_shmem_get_channel_description(const pirate_shmem_param_t *param, char *desc, int len);
-int pirate_shmem_open(int flags, pirate_shmem_param_t *param, shmem_ctx *ctx);
+int pirate_shmem_open(pirate_shmem_param_t *param, shmem_ctx *ctx);
 int pirate_shmem_close(shmem_ctx *ctx);
 ssize_t pirate_shmem_read(const pirate_shmem_param_t *param, shmem_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_shmem_write(const pirate_shmem_param_t *param, shmem_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/tcp_socket.c
+++ b/libpirate/tcp_socket.c
@@ -193,9 +193,9 @@ static int tcp_socket_writer_open(pirate_tcp_socket_param_t *param, tcp_socket_c
     return -1;
 }
 
-int pirate_tcp_socket_open(int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx) {
+int pirate_tcp_socket_open(pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx) {
     int rv = -1;
-    int access = flags & O_ACCMODE;
+    int access = ctx->flags & O_ACCMODE;
 
     pirate_tcp_socket_init_param(param);
     if (param->port <= 0) {

--- a/libpirate/tcp_socket.h
+++ b/libpirate/tcp_socket.h
@@ -19,12 +19,13 @@
 #include "libpirate.h"
 
 typedef struct {
+    int flags;
     int sock;
 } tcp_socket_ctx;
 
 int pirate_tcp_socket_parse_param(char *str, pirate_tcp_socket_param_t *param);
 int pirate_tcp_socket_get_channel_description(const pirate_tcp_socket_param_t *param, char *desc, int len);
-int pirate_tcp_socket_open(int flags, pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx);
+int pirate_tcp_socket_open(pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx);
 int pirate_tcp_socket_close(tcp_socket_ctx *ctx);
 ssize_t pirate_tcp_socket_read(const pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_tcp_socket_write(const pirate_tcp_socket_param_t *param, tcp_socket_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/udp_shmem.c
+++ b/libpirate/udp_shmem.c
@@ -268,11 +268,11 @@ error:
     return NULL;
 }
 
-int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
+int udp_shmem_buffer_open(pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
-    int access = flags & O_ACCMODE;
+    int access = ctx->flags & O_ACCMODE;
 
     udp_shmem_buffer_init_param(param);
     if (strnlen(param->path, 1) == 0) {
@@ -335,7 +335,6 @@ int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_
         }
     }
 
-    ctx->flags = flags;
     return 0;
 error:
     err = errno;

--- a/libpirate/udp_shmem.h
+++ b/libpirate/udp_shmem.h
@@ -20,7 +20,7 @@
 
 int udp_shmem_buffer_parse_param(char *str, pirate_udp_shmem_param_t *param);
 int udp_shmem_buffer_get_channel_description(const pirate_udp_shmem_param_t *param, char *desc, int len);
-int udp_shmem_buffer_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
+int udp_shmem_buffer_open(pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
 int udp_shmem_buffer_close(udp_shmem_ctx *ctx);
 ssize_t udp_shmem_buffer_read(const pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx, void *buf,
                             size_t count);

--- a/libpirate/udp_shmem_interface.c
+++ b/libpirate/udp_shmem_interface.c
@@ -38,11 +38,11 @@ int pirate_udp_shmem_get_channel_description(const pirate_udp_shmem_param_t *par
 #endif
 }
 
-int pirate_udp_shmem_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
+int pirate_udp_shmem_open(pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx) {
 #ifdef PIRATE_SHMEM_FEATURE
-    return udp_shmem_buffer_open(flags, param, ctx);
+    return udp_shmem_buffer_open(param, ctx);
 #else
-    (void) flags, (void) param, (void) ctx;
+    (void) param, (void) ctx;
     return -1;
 #endif
 }

--- a/libpirate/udp_shmem_interface.h
+++ b/libpirate/udp_shmem_interface.h
@@ -26,7 +26,7 @@ typedef struct {
 
 int pirate_udp_shmem_parse_param(char *str, pirate_udp_shmem_param_t *param);
 int pirate_udp_shmem_get_channel_description(const pirate_udp_shmem_param_t *param, char *desc, int len);
-int pirate_udp_shmem_open(int flags, pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
+int pirate_udp_shmem_open(pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx);
 int pirate_udp_shmem_close(udp_shmem_ctx *ctx);
 ssize_t pirate_udp_shmem_read(const pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_udp_shmem_write(const pirate_udp_shmem_param_t *param, udp_shmem_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -162,9 +162,9 @@ static int udp_socket_writer_open(pirate_udp_socket_param_t *param, udp_socket_c
     return 0;
 }
 
-int pirate_udp_socket_open(int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
+int pirate_udp_socket_open(pirate_udp_socket_param_t *param, udp_socket_ctx *ctx) {
     int rv = -1;
-    int access = flags & O_ACCMODE;
+    int access = ctx->flags & O_ACCMODE;
 
     pirate_udp_socket_init_param(param);
     if (param->port <= 0) {

--- a/libpirate/udp_socket.h
+++ b/libpirate/udp_socket.h
@@ -19,12 +19,13 @@
 #include "libpirate.h"
 
 typedef struct {
+    int flags;
     int sock;
 } udp_socket_ctx;
 
 int pirate_udp_socket_parse_param(char *str, pirate_udp_socket_param_t *param);
 int pirate_udp_socket_get_channel_description(const pirate_udp_socket_param_t *param, char *desc, int len);
-int pirate_udp_socket_open(int flags, pirate_udp_socket_param_t *param, udp_socket_ctx *ctx);
+int pirate_udp_socket_open(pirate_udp_socket_param_t *param, udp_socket_ctx *ctx);
 int pirate_udp_socket_close(udp_socket_ctx *ctx);
 ssize_t pirate_udp_socket_read(const pirate_udp_socket_param_t *param, udp_socket_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_udp_socket_write(const pirate_udp_socket_param_t *param, udp_socket_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/uio.c
+++ b/libpirate/uio.c
@@ -116,11 +116,11 @@ static shmem_buffer_t *uio_buffer_init(unsigned short region, int fd) {
     return uio_buffer;
 }
 
-int pirate_internal_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
+int pirate_internal_uio_open(pirate_uio_param_t *param, uio_ctx *ctx) {
     int err;
     uint_fast64_t init_pid = 0;
     shmem_buffer_t* buf;
-    int access = flags & O_ACCMODE;
+    int access = ctx->flags & O_ACCMODE;
 
     pirate_uio_init_param(param);
     ctx->fd = open(param->path, O_RDWR | O_SYNC);
@@ -157,7 +157,6 @@ int pirate_internal_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx)
         } while (!init_pid);
     }
 
-    ctx->flags = flags;
     return 0;
 error:
     err = errno;

--- a/libpirate/uio.h
+++ b/libpirate/uio.h
@@ -20,7 +20,7 @@
 
 int pirate_internal_uio_parse_param(char *str, pirate_uio_param_t *param);
 int pirate_internal_uio_get_channel_description(const pirate_uio_param_t *param, char *desc, int len);
-int pirate_internal_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx);
+int pirate_internal_uio_open(pirate_uio_param_t *param, uio_ctx *ctx);
 int pirate_internal_uio_close(uio_ctx *ctx);
 ssize_t pirate_internal_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_internal_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/uio_interface.c
+++ b/libpirate/uio_interface.c
@@ -38,11 +38,11 @@ int pirate_uio_get_channel_description(const pirate_uio_param_t *param, char *de
 #endif
 }
 
-int pirate_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx) {
+int pirate_uio_open(pirate_uio_param_t *param, uio_ctx *ctx) {
 #ifdef PIRATE_SHMEM_FEATURE
-    return pirate_internal_uio_open(flags, param, ctx);
+    return pirate_internal_uio_open(param, ctx);
 #else
-    (void) flags, (void) param, (void) ctx;
+    (void) param, (void) ctx;
     errno = ESOCKTNOSUPPORT;
     return -1;
 #endif

--- a/libpirate/uio_interface.h
+++ b/libpirate/uio_interface.h
@@ -20,14 +20,14 @@
 #include "shmem_buffer.h"
 
 typedef struct {
-    int fd;
     int flags;
+    int fd;
     shmem_buffer_t *buf;
 } uio_ctx;
 
 int pirate_uio_parse_param(char *str, pirate_uio_param_t *param);
 int pirate_uio_get_channel_description(const pirate_uio_param_t *param, char *desc, int len);
-int pirate_uio_open(int flags, pirate_uio_param_t *param, uio_ctx *ctx);
+int pirate_uio_open(pirate_uio_param_t *param, uio_ctx *ctx);
 int pirate_uio_close(uio_ctx *ctx);
 ssize_t pirate_uio_read(const pirate_uio_param_t *param, uio_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_uio_write(const pirate_uio_param_t *param, uio_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/unix_socket.c
+++ b/libpirate/unix_socket.c
@@ -171,9 +171,9 @@ static int unix_socket_writer_open(pirate_unix_socket_param_t *param, unix_socke
     return -1;
 }
 
-int pirate_unix_socket_open(int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx) {
+int pirate_unix_socket_open(pirate_unix_socket_param_t *param, unix_socket_ctx *ctx) {
     int rv = -1;
-    int access = flags & O_ACCMODE;
+    int access = ctx->flags & O_ACCMODE;
 
     if (strnlen(param->path, 1) == 0) {
         errno = EINVAL;

--- a/libpirate/unix_socket.h
+++ b/libpirate/unix_socket.h
@@ -19,12 +19,13 @@
 #include "libpirate.h"
 
 typedef struct {
+    int flags;
     int sock;
 } unix_socket_ctx;
 
 int pirate_unix_socket_parse_param(char *str, pirate_unix_socket_param_t *param);
 int pirate_unix_socket_get_channel_description(const pirate_unix_socket_param_t *param, char *desc, int len);
-int pirate_unix_socket_open(int flags, pirate_unix_socket_param_t *param, unix_socket_ctx *ctx);
+int pirate_unix_socket_open(pirate_unix_socket_param_t *param, unix_socket_ctx *ctx);
 int pirate_unix_socket_close(unix_socket_ctx *ctx);
 ssize_t pirate_unix_socket_read(const pirate_unix_socket_param_t *param, unix_socket_ctx *ctx, void *buf, size_t count);
 ssize_t pirate_unix_socket_write(const pirate_unix_socket_param_t *param, unix_socket_ctx *ctx, const void *buf, size_t count);

--- a/libpirate/yield.c
+++ b/libpirate/yield.c
@@ -1,5 +1,5 @@
 #include "libpirate.h"
-#include "libpirate_internal.h"
+#include "pirate_common.h"
 
 #include <errno.h>
 #include <poll.h>

--- a/libpirate/yield.cpp
+++ b/libpirate/yield.cpp
@@ -1,5 +1,5 @@
 #include "libpirate.h"
-#include "libpirate_internal.h"
+#include "pirate_common.h"
 #include "libpirate.hpp"
 
 #include <limits.h>
@@ -27,6 +27,7 @@ extern int gaps_writer_control_gds[PIRATE_NUM_ENCLAVES];
 int pirate::internal::cooperative_register(int gd, void* func, size_t len) {
     pirate_listener_t listener;
     pirate_channel_param_t *param;
+    common_ctx *ctx;
     listener.func = func;
     listener.len = len;
     if ((gd < 0) || (gd >= PIRATE_NUM_CHANNELS)) {
@@ -45,7 +46,11 @@ int pirate::internal::cooperative_register(int gd, void* func, size_t len) {
         errno = EPERM;
         return -1;
     }
-    if ((pirate_get_channel_flags(gd) & O_ACCMODE) != O_RDONLY) {
+    ctx = pirate_get_common_ctx_ref(gd);
+    if (ctx == NULL) {
+        return -1;
+    }
+    if ((ctx->flags & O_ACCMODE) != O_RDONLY) {
         errno = EPERM;
         return -1;
     }


### PR DESCRIPTION
Refactor the flags and fd into a common context struct. Eliminates passing the flags field to open() functions.