### PR TITLE
Change `len - 1` to `len` in libpirate `*_get_channel_description`

### DIFF
--- a/libpirate/device.c
+++ b/libpirate/device.c
@@ -57,7 +57,7 @@ int pirate_device_parse_param(char *str, pirate_device_param_t *param) {
 }
 
 int pirate_device_get_channel_description(const pirate_device_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "device,%s,iov_len=%u", param->path, param->iov_len);
+    return snprintf(desc, len, "device,%s,iov_len=%u", param->path, param->iov_len);
 }
 
 int pirate_device_open(int flags, pirate_device_param_t *param, device_ctx *ctx) {

--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -183,7 +183,7 @@ int pirate_ge_eth_parse_param(char *str, pirate_ge_eth_param_t *param) {
 }
 
 int pirate_ge_eth_get_channel_description(const pirate_ge_eth_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "ge_eth,%s,%u,%u,mtu=%u", param->addr,
+    return snprintf(desc, len, "ge_eth,%s,%u,%u,mtu=%u", param->addr,
                     param->port, param->message_id, param->mtu);
 }
 

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -297,7 +297,7 @@ int pirate_mercury_get_channel_description(const pirate_mercury_param_t *param, 
     for (uint32_t i = 0; i < param->session.message_count; ++i) {
         wr += wr_sz;
         len -= wr_sz;
-        wr_sz = snprintf(wr, len - 1, ",%u", param->session.messages[i]);
+        wr_sz = snprintf(wr, len, ",%u", param->session.messages[i]);
         ret_sz += wr_sz;
     }
 

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -288,7 +288,7 @@ int pirate_mercury_get_channel_description(const pirate_mercury_param_t *param, 
     int wr_sz = 0;
     int ret_sz = 0;
 
-    wr_sz = snprintf(wr, len - 1, "mercury,%u,%u,%u", 
+    wr_sz = snprintf(wr, len, "mercury,%u,%u,%u", 
                         param->session.level, 
                         param->session.source_id,
                         param->session.destination_id);

--- a/libpirate/pipe.c
+++ b/libpirate/pipe.c
@@ -57,7 +57,7 @@ int pirate_pipe_parse_param(char *str, pirate_pipe_param_t *param) {
 }
 
 int pirate_pipe_get_channel_description(const pirate_pipe_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "pipe,%s,iov_len=%u", param->path, param->iov_len);
+    return snprintf(desc, len, "pipe,%s,iov_len=%u", param->path, param->iov_len);
 }
 
 int pirate_pipe_open(int flags, pirate_pipe_param_t *param, pipe_ctx *ctx) {

--- a/libpirate/serial.c
+++ b/libpirate/serial.c
@@ -105,7 +105,7 @@ int pirate_serial_get_channel_description(const pirate_serial_param_t *param, ch
         return -1;
     }
 
-    return snprintf(desc, len - 1, "serial,%s,baud=%s,mtu=%u", param->path, baud,
+    return snprintf(desc, len, "serial,%s,baud=%s,mtu=%u", param->path, baud,
                     param->mtu);
 }
 

--- a/libpirate/shmem.c
+++ b/libpirate/shmem.c
@@ -216,7 +216,7 @@ int shmem_buffer_parse_param(char *str, pirate_shmem_param_t *param) {
 }
 
 int shmem_buffer_get_channel_description(const pirate_shmem_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "shmem,%s,buffer_size=%u", param->path,
+    return snprintf(desc, len, "shmem,%s,buffer_size=%u", param->path,
                     param->buffer_size);
 }
 

--- a/libpirate/tcp_socket.c
+++ b/libpirate/tcp_socket.c
@@ -73,7 +73,7 @@ int pirate_tcp_socket_parse_param(char *str, pirate_tcp_socket_param_t *param) {
 }
 
 int pirate_tcp_socket_get_channel_description(const pirate_tcp_socket_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "tcp_socket,%s,%u,iov_len=%u,buffer_size=%u", param->addr,
+    return snprintf(desc, len, "tcp_socket,%s,%u,iov_len=%u,buffer_size=%u", param->addr,
                     param->port, param->iov_len, param->buffer_size);
 }
 

--- a/libpirate/test/common_test.cpp
+++ b/libpirate/test/common_test.cpp
@@ -94,4 +94,30 @@ TEST(CommonChannel, RegisterEnclave)
     ASSERT_EQ(1u, param.dst_enclave);
 }
 
+TEST(CommonChannel, UnparseChannelParam)
+{
+    char output[80];
+    int rv;
+    pirate_channel_param_t param;
+
+    rv = pirate_parse_channel_param("device,/dev/null,iov_len=0", &param);
+    ASSERT_EQ(0, rv);
+    ASSERT_EQ(0, errno);
+
+    rv = pirate_unparse_channel_param(&param, output, 80);
+    ASSERT_EQ(26, rv);
+    ASSERT_EQ(0, errno);
+    ASSERT_STREQ("device,/dev/null,iov_len=0", output);
+
+    rv = pirate_unparse_channel_param(&param, output, 26);
+    ASSERT_EQ(26, rv);
+    ASSERT_EQ(0, errno);
+    ASSERT_STREQ("device,/dev/null,iov_len=", output);
+
+    rv = pirate_unparse_channel_param(&param, output, 25);
+    ASSERT_EQ(26, rv);
+    ASSERT_EQ(0, errno);    
+    ASSERT_STREQ("device,/dev/null,iov_len", output);
+}
+
 } // namespace

--- a/libpirate/udp_shmem.c
+++ b/libpirate/udp_shmem.c
@@ -151,7 +151,7 @@ int udp_shmem_buffer_parse_param(char *str, pirate_udp_shmem_param_t *param) {
 }
 
 int udp_shmem_buffer_get_channel_description(const pirate_udp_shmem_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "udp_shmem,%s,buffer_size=%u,packet_size=%zd,packet_count=%zd", param->path,
+    return snprintf(desc, len, "udp_shmem,%s,buffer_size=%u,packet_size=%zd,packet_count=%zd", param->path,
                 param->buffer_size, param->packet_size,
                 param->packet_count);
 }

--- a/libpirate/udp_socket.c
+++ b/libpirate/udp_socket.c
@@ -71,7 +71,7 @@ int pirate_udp_socket_parse_param(char *str, pirate_udp_socket_param_t *param) {
 }
 
 int pirate_udp_socket_get_channel_description(const pirate_udp_socket_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "udp_socket,%s,%u,iov_len=%u,buffer_size=%u", param->addr,
+    return snprintf(desc, len, "udp_socket,%s,%u,iov_len=%u,buffer_size=%u", param->addr,
                     param->port, param->iov_len, param->buffer_size);
 }
 

--- a/libpirate/uio.c
+++ b/libpirate/uio.c
@@ -101,7 +101,7 @@ int pirate_internal_uio_parse_param(char *str, pirate_uio_param_t *param) {
 }
 
 int pirate_internal_uio_get_channel_description(const pirate_uio_param_t *param, char *desc, int len) {
-    return snprintf(desc, len - 1, "uio,path=%s", param->path);
+    return snprintf(desc, len, "uio,path=%s", param->path);
 }
 
 static shmem_buffer_t *uio_buffer_init(unsigned short region, int fd) {

--- a/libpirate/unix_socket.c
+++ b/libpirate/unix_socket.c
@@ -60,7 +60,7 @@ int pirate_unix_socket_parse_param(char *str, pirate_unix_socket_param_t *param)
 }
 
 int pirate_unix_socket_get_channel_description(const pirate_unix_socket_param_t *param,char *desc, int len) {
-    return snprintf(desc, len - 1, "unix_socket,%s,iov_len=%u,buffer_size=%u", param->path,
+    return snprintf(desc, len, "unix_socket,%s,iov_len=%u,buffer_size=%u", param->path,
                     param->iov_len, param->buffer_size);
 }
 


### PR DESCRIPTION
This branch fixes an off-by-one error in calls to `snprintf` in the libpirate `*_get_channel_description` functions.