### PR TITLE
Make sure dummy resource sections are empty by default

### DIFF
--- a/demos/word_filter/1.pal/CMakeLists.txt
+++ b/demos/word_filter/1.pal/CMakeLists.txt
@@ -8,7 +8,7 @@ set(HIGH "filter_host")
 set(LOW "filter_ui")
 
 # Build flags
-set(BUILD_FLAGS "-Werror" "-Wall" "-Wextra" "-Wpedantic" "-O0")
+set(BUILD_FLAGS "-Werror" "-Wall" "-Wextra" "-Wpedantic" "-Wno-zero-length-array" "-O0")
 set(BUILD_FLAGS ${BUILD_FLAGS} "-ffunction-sections" "-fdata-sections" "--target=x86_64-pc-linux-elf")
 # set(BUILD_FLAGS ${BUILD_FLAGS} "SHELL:-Xclang -load" "SHELL:-Xclang PropagateEnclaves.so")
 

--- a/pal/include/pal/pal.h
+++ b/pal/include/pal/pal.h
@@ -31,15 +31,15 @@ typedef bool    pal_boolean    __attribute__((pirate_resource_type("boolean")));
 typedef int     pal_file       __attribute__((pirate_resource_type("file")));
 typedef int     pirate_channel __attribute__((pirate_resource_type("pirate_channel")));
 
-struct pirate_resource _dummy_pirate_res_string[1]
+struct pirate_resource _dummy_pirate_res_string[0]
     __attribute__((used, section(".pirate.res.string")));
-struct pirate_resource _dummy_pirate_res_integer[1]
+struct pirate_resource _dummy_pirate_res_integer[0]
     __attribute__((used, section(".pirate.res.integer")));
-struct pirate_resource _dummy_pirate_res_boolean[1]
+struct pirate_resource _dummy_pirate_res_boolean[0]
     __attribute__((used, section(".pirate.res.boolean")));
-struct pirate_resource _dummy_pirate_res_file[1]
+struct pirate_resource _dummy_pirate_res_file[0]
     __attribute__((used, section(".pirate.res.file")));
-struct pirate_resource _dummy_pirate_res_pirate_channel[1]
+struct pirate_resource _dummy_pirate_res_pirate_channel[0]
     __attribute__((used, section(".pirate.res.pirate_channel")));
 // ^ FIXME: Remove this once it's taken care of in clang
 


### PR DESCRIPTION
Dummy resource sections must be empty in order to prevent the resource init functions from trying to read resource objects from uninitialized memory. This requires extensions, but should be OK for the time being, since the dummy resource sections can be removed once clang creates empty resource sections. Passing `-Wno-zero-length-array` can be used to silence warnings in conjunction with `-Wpedantic`.