### PR TITLE
Fix Ninja builds by declaring libcyaml.so as build byproduct

### DIFF
--- a/pal/CMakeLists.txt
+++ b/pal/CMakeLists.txt
@@ -30,6 +30,7 @@ ExternalProject_Add(project_libcyaml
     BUILD_COMMAND make VARIANT=release
     INSTALL_COMMAND make install
     PREFIX=${CMAKE_CURRENT_BINARY_DIR}/libcyaml-1.0.2
+    BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/libcyaml-1.0.2/lib/libcyaml.so
 )
 
 add_library(libcyaml SHARED IMPORTED)


### PR DESCRIPTION
Builds using Ninja as the generator were producing the following error:

`ninja: error: 'pal/libcyaml-1.0.2/lib/libcyaml.so', needed by 'pal/pal', missing and no known rule to make it`

Ninja is very picky about knowing where to find dependencies and needs to be informed that this library is a byproduct of the build in the external project.

See:
https://gitlab.kitware.com/cmake/cmake/commit/557aef0b94c86d13e802e6e8e34a491304d7be2f 
and
http://cmake.3232098.n2.nabble.com/ExternalProject-Add-static-library-Ninja-generator-td7590158.html