### PR TITLE
Harmonize close() semantics on unix pipe, unix socket, and tcp socket

### DIFF
--- a/libpirate/pirate_common.c
+++ b/libpirate/pirate_common.c
@@ -26,7 +26,7 @@ static ssize_t pirate_stream_do_read(int fd, uint8_t *buf, size_t count) {
     ssize_t rv;
     while (rx < count) {
         rv = read(fd, buf + rx, count - rx);
-        if (rv < 0) {
+        if (rv <= 0) {
             return rv;
         }
         rx += rv;
@@ -47,7 +47,7 @@ ssize_t pirate_stream_read(common_ctx *ctx, size_t min_tx, void *buf, size_t cou
     }
 
     rv = pirate_stream_do_read(fd, ctx->min_tx_buf, min_tx);
-    if (rv < 0) {
+    if (rv <= 0) {
         return rv;
     }
     packet_count = ntohl(header->count);
@@ -56,7 +56,7 @@ ssize_t pirate_stream_read(common_ctx *ctx, size_t min_tx, void *buf, size_t cou
     memcpy(buf, ctx->min_tx_buf + sizeof(pirate_header_t), min_tx_data);
     if (min_tx_data < count) {
         rv = pirate_stream_do_read(fd, ((uint8_t*) buf) + min_tx_data, count - min_tx_data);
-        if (rv < 0) {
+        if (rv <= 0) {
             return rv;
         }
     }
@@ -66,7 +66,7 @@ ssize_t pirate_stream_read(common_ctx *ctx, size_t min_tx, void *buf, size_t cou
         uint8_t *temp = malloc(packet_count - rx);
         rv = pirate_stream_do_read(fd, temp, packet_count - rx);
         free(temp);
-        if (rv < 0) {
+        if (rv <= 0) {
             return rv;
         }
     }

--- a/libpirate/test/channel_test.cpp
+++ b/libpirate/test/channel_test.cpp
@@ -155,7 +155,6 @@ void ChannelTest::RunChildOpen(bool child)
     void *WriterStatus, *ReaderStatus;
 
     childOpen = child;
-    errno = 0;
 
     ChannelInit();
 

--- a/libpirate/test/channel_test.cpp
+++ b/libpirate/test/channel_test.cpp
@@ -155,6 +155,7 @@ void ChannelTest::RunChildOpen(bool child)
     void *WriterStatus, *ReaderStatus;
 
     childOpen = child;
+    errno = 0;
 
     ChannelInit();
 
@@ -261,5 +262,67 @@ void ChannelTest::ReaderTest()
 
     ReaderChannelClose();
 }
+
+void HalfClosedTest::ReaderTest()
+{
+    if (childOpen)
+    {
+        ReaderChannelOpen();
+    }
+}
+
+void HalfClosedTest::WriterTest()
+{
+    if (childOpen)
+    {
+        WriterChannelOpen();
+    }
+}
+
+void ClosedWriterTest::RunChildOpen(bool child)
+{
+    int rv;
+
+    ChannelTest::RunChildOpen(child);
+
+    WriterChannelClose();
+
+    rv = pirate_read(Reader.gd, Reader.buf, buf_size);
+    ASSERT_EQ(errno, 0);
+    ASSERT_EQ(rv, 0);
+
+    ReaderChannelClose();
+}
+
+void ClosedReaderTest::RunChildOpen(bool child)
+{
+    int rv;
+    struct sigaction new_action, prev_action;
+
+    ChannelTest::RunChildOpen(child);
+
+    memset(&new_action, 0, sizeof(new_action));
+    new_action.sa_handler = SIG_IGN;
+    new_action.sa_flags = 0;
+
+    rv = sigaction(SIGPIPE, &new_action, &prev_action);
+    ASSERT_EQ(errno, 0);
+    ASSERT_EQ(rv, 0);
+
+    ReaderChannelClose();
+
+    WriteDataInit(buf_size);
+    rv = pirate_write(Writer.gd, Writer.buf, buf_size);
+    ASSERT_EQ(errno, EPIPE);
+    ASSERT_EQ(rv, -1);
+    errno = 0;
+
+    WriterChannelClose();
+
+    rv = sigaction(SIGPIPE, &prev_action, NULL);
+    ASSERT_EQ(errno, 0);
+    ASSERT_EQ(rv, 0);
+}
+
 
 } // namespace

--- a/libpirate/test/channel_test.hpp
+++ b/libpirate/test/channel_test.hpp
@@ -45,10 +45,11 @@ protected:
     virtual void WriterChannelClose();
     virtual void ReaderChannelClose();
 
+    virtual void WriterTest();
+    virtual void ReaderTest();
+
     void Run();
-    void RunChildOpen(bool child);
-    void WriterTest();
-    void ReaderTest();
+    virtual void RunChildOpen(bool child);
 
     struct TestPoint {
         TestPoint() : 
@@ -94,6 +95,25 @@ public:
     ChannelTest();
     static void *WriterThreadS(void *param);
     static void *ReaderThreadS(void *param);
+};
+
+class HalfClosedTest : public ChannelTest
+{
+protected:
+    virtual void WriterTest() override;
+    virtual void ReaderTest() override;
+};
+
+class ClosedWriterTest : public HalfClosedTest
+{
+public:
+    virtual void RunChildOpen(bool child) override;
+};
+
+class ClosedReaderTest : public HalfClosedTest
+{
+public:
+    virtual void RunChildOpen(bool child) override;
 };
 
 static const unsigned TEST_MIN_TX_LEN = 16;

--- a/libpirate/test/pipe_test.cpp
+++ b/libpirate/test/pipe_test.cpp
@@ -80,4 +80,40 @@ TEST_P(PipeTest, Run)
 INSTANTIATE_TEST_SUITE_P(PipeFunctionalTest, PipeTest,
     Values(0, TEST_MIN_TX_LEN));
 
+class PipeCloseWriterTest : public ClosedWriterTest
+{
+public:
+    void ChannelInit()
+    {
+        pirate_pipe_param_t *param = &Reader.param.channel.pipe;
+
+        pirate_init_channel_param(PIPE, &Reader.param);
+        strncpy(param->path, "/tmp/gaps.channel.test", PIRATE_LEN_NAME);
+        Writer.param = Reader.param;
+    }
+};
+
+TEST_F(PipeCloseWriterTest, Run)
+{
+    Run();
+}
+
+class PipeCloseReaderTest : public ClosedReaderTest
+{
+public:
+    void ChannelInit()
+    {
+        pirate_pipe_param_t *param = &Reader.param.channel.pipe;
+
+        pirate_init_channel_param(PIPE, &Reader.param);
+        strncpy(param->path, "/tmp/gaps.channel.test", PIRATE_LEN_NAME);
+        Writer.param = Reader.param;
+    }
+};
+
+TEST_F(PipeCloseReaderTest, Run)
+{
+    Run();
+}
+
 } // namespace

--- a/libpirate/test/tcp_socket_test.cpp
+++ b/libpirate/test/tcp_socket_test.cpp
@@ -107,4 +107,42 @@ INSTANTIATE_TEST_SUITE_P(TcpSocketFunctionalTest, TcpSocketTest,
     Values(std::make_tuple(0, 0),
         std::make_tuple(TEST_BUF_LEN, TEST_MIN_TX_LEN)));
 
+class TcpSocketCloseWriterTest : public ClosedWriterTest
+{
+public:
+    void ChannelInit()
+    {
+        pirate_tcp_socket_param_t *param = &Reader.param.channel.tcp_socket;
+
+        pirate_init_channel_param(TCP_SOCKET, &Reader.param);
+        snprintf(param->addr, sizeof(param->addr) - 1, PIRATE_DEFAULT_TCP_IP_ADDR);
+        param->port = 26427;
+        Writer.param = Reader.param;
+    }
+};
+
+TEST_F(TcpSocketCloseWriterTest, Run)
+{
+    Run();
+}
+
+class TcpSocketCloseReaderTest : public ClosedReaderTest
+{
+public:
+    void ChannelInit()
+    {
+        pirate_tcp_socket_param_t *param = &Reader.param.channel.tcp_socket;
+
+        pirate_init_channel_param(TCP_SOCKET, &Reader.param);
+        snprintf(param->addr, sizeof(param->addr) - 1, PIRATE_DEFAULT_TCP_IP_ADDR);
+        param->port = 26427;
+        Writer.param = Reader.param;
+    }
+};
+
+TEST_F(TcpSocketCloseReaderTest, Run)
+{
+    Run();
+}
+
 } // namespace

--- a/libpirate/test/unix_socket_test.cpp
+++ b/libpirate/test/unix_socket_test.cpp
@@ -97,4 +97,40 @@ INSTANTIATE_TEST_SUITE_P(UnixSocketFunctionalTest, UnixSocketTest,
     Values(std::make_tuple(0, 0),
         std::make_tuple(TEST_BUF_LEN, TEST_MIN_TX_LEN)));
 
+class UnixSocketCloseWriterTest : public ClosedWriterTest
+{
+public:
+    void ChannelInit()
+    {
+        pirate_unix_socket_param_t *param = &Reader.param.channel.unix_socket;
+
+        pirate_init_channel_param(UNIX_SOCKET, &Reader.param);
+        strncpy(param->path, "/tmp/gaps.channel.test.sock", PIRATE_LEN_NAME);
+        Writer.param = Reader.param;
+    }
+};
+
+TEST_F(UnixSocketCloseWriterTest, Run)
+{
+    Run();
+}
+
+class UnixSocketCloseReaderTest : public ClosedReaderTest
+{
+public:
+    void ChannelInit()
+    {
+        pirate_unix_socket_param_t *param = &Reader.param.channel.unix_socket;
+
+        pirate_init_channel_param(UNIX_SOCKET, &Reader.param);
+        strncpy(param->path, "/tmp/gaps.channel.test.sock", PIRATE_LEN_NAME);
+        Writer.param = Reader.param;
+    }
+};
+
+TEST_F(UnixSocketCloseReaderTest, Run)
+{
+    Run();
+}
+
 } // namespace


### PR DESCRIPTION
If the writer closes first then the reader receives a return value of 0 on the next read() request. If the reader closes first then the writer receives a SIGPIPE signal and an EPIPE errno on the next write() request. Add one set of shared unit tests to confirm same behavior across unix pipe, unix socket, and tcp socket. This behavior is only on connection-oriented channels.

On the tcp reader set socket option SO_LINGER to onoff=1 and linger=0. This causes the reader to send a RST packet and reset the connection on close(). Graceful TCP connection termination is two pairs of two-way FIN, ACK handshakes. Graceful termination would require the writer to read() and receive a return value of 0. Since a gaps writer must not call read() we use a RST packet sent from the reader to close the conection. libpirate ignores the ECONNRESET error code when received by the tcp writer on close(). SO_LINGER socket option is not set on the writer.