### PR TITLE
mercury channel description bugfixes

### DIFF
--- a/libpirate/ge_eth.c
+++ b/libpirate/ge_eth.c
@@ -176,7 +176,7 @@ int pirate_ge_eth_get_channel_description(const void *_param, char *desc, int le
     char mtu_str[32];
 
     mtu_str[0] = 0;
-    if ((param->mtu != 0) && (param->mtu != PIRATE_DEFAULT_GE_ETH_MTU)) {
+    if (param->mtu != 0) {
         snprintf(mtu_str, 32, ",mtu=%u", param->mtu);
     }
     return snprintf(desc, len, "ge_eth,%s,%u,%u%s", param->addr,

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -285,10 +285,18 @@ int pirate_mercury_get_channel_description(const void *_param, char *desc, int l
     int wr_sz = 0;
     int ret_sz = 0;
 
-    wr_sz = snprintf(wr, len, "mercury,%u,%u,%u", 
-                        param->session.level, 
+    char mtu_str[32];
+
+    mtu_str[0] = 0;
+    if (param->mtu != 0) {
+        snprintf(mtu_str, 32, ",mtu=%u", param->mtu);
+    }
+
+    wr_sz = snprintf(wr, len, "mercury,%u,%u,%u%s",
+                        param->session.level,
                         param->session.source_id,
-                        param->session.destination_id);
+                        param->session.destination_id,
+                        mtu_str);
     ret_sz += wr_sz;
 
     for (uint32_t i = 0; i < param->session.message_count; ++i) {

--- a/libpirate/mercury.c
+++ b/libpirate/mercury.c
@@ -301,7 +301,7 @@ int pirate_mercury_get_channel_description(const void *_param, char *desc, int l
 
     for (uint32_t i = 0; i < param->session.message_count; ++i) {
         wr += wr_sz;
-        len -= wr_sz;
+        len = MAX(len - wr_sz, 0);
         wr_sz = snprintf(wr, len, ",%u", param->session.messages[i]);
         ret_sz += wr_sz;
     }

--- a/libpirate/test/mercury_test.cpp
+++ b/libpirate/test/mercury_test.cpp
@@ -106,6 +106,31 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
     EXPECT_TRUE(0 == std::memcmp(&expParam, &rdParam, sizeof(rdParam)));
 }
 
+TEST(ChannelMercuryTest, UnparseChannelParam)
+{
+    char *output;
+    int rv;
+    pirate_channel_param_t param;
+
+    rv = pirate_parse_channel_param("mercury,0,1,2,3", &param);
+    ASSERT_EQ(0, rv);
+    ASSERT_EQ(0, errno);
+
+    output = (char*) calloc(16, sizeof(char));
+    rv = pirate_unparse_channel_param(&param, output, 16);
+    ASSERT_EQ(15, rv);
+    ASSERT_EQ(0, errno);
+    ASSERT_STREQ("mercury,0,1,2,3", output);
+    free(output);
+
+    output = (char*) calloc(4, sizeof(char));
+    rv = pirate_unparse_channel_param(&param, output, 4);
+    ASSERT_EQ(15, rv);
+    ASSERT_EQ(0, errno);
+    ASSERT_STREQ("mer", output);
+    free(output);
+}
+
 TEST(ChannelMercuryTest, DefaultSession) {
     int rv = 0;
     int rchannel, wchannel;

--- a/libpirate/test/mercury_test.cpp
+++ b/libpirate/test/mercury_test.cpp
@@ -30,6 +30,7 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
     pirate_channel_param_t expParam, rdParam;
     char opt[256];
     const char *name = "mercury";
+    const uint32_t mtu = 42;
     const uint32_t level = 1;
     const uint32_t src_id = 2;
     const uint32_t dst_id = 3;
@@ -66,11 +67,22 @@ TEST(ChannelMercuryTest, ConfigurationParser) {
     expParam.channel.mercury.mtu = 0;
     EXPECT_TRUE(0 == std::memcmp(&expParam, &rdParam, sizeof(rdParam)));
 
+    snprintf(opt, sizeof(opt) - 1, "%s,%u,%u,%u,mtu=%u", name, level, src_id, dst_id, mtu);
+    rv = pirate_parse_channel_param(opt, &rdParam);
+    ASSERT_EQ(0, errno);
+    ASSERT_EQ(0, rv);
+    expParam.channel.mercury.session.level = level;
+    expParam.channel.mercury.session.source_id = src_id;
+    expParam.channel.mercury.session.destination_id = dst_id;
+    expParam.channel.mercury.mtu = mtu;
+    EXPECT_TRUE(0 == std::memcmp(&expParam, &rdParam, sizeof(rdParam)));
+
     snprintf(opt, sizeof(opt) - 1, "%s,%u,%u,%u,%u", name, level, src_id,
             dst_id, msg_ids[0]);
     rv = pirate_parse_channel_param(opt, &rdParam);
     ASSERT_EQ(0, errno);
     ASSERT_EQ(0, rv);
+    expParam.channel.mercury.mtu = 0;
     expParam.channel.mercury.session.message_count = 1;
     expParam.channel.mercury.session.messages[0] = msg_ids[0];
     EXPECT_TRUE(0 == std::memcmp(&expParam, &rdParam, sizeof(rdParam)));


### PR DESCRIPTION
Fixes mtu ignored in pirate_mercury_get_channel_description and buffer overflow in pirate_mercury_get_channel_description. Adds unit tests for both cases. Closes #108. Closes #109.