### PR TITLE
Add XWindows frame processor to camera_demo

### DIFF
--- a/demos/camera_demo/CMakeLists.txt
+++ b/demos/camera_demo/CMakeLists.txt
@@ -11,6 +11,8 @@ set(BUILD_FALGS -std=c++11 ${PIRATE_C_FLAGS})
 # Libraries
 find_library(FREESPACE_LIB freespace)
 find_library(PIGPIO_LIB pigpio)
+find_library(JPEG_LIB jpeg)
+find_library(X11_LIB X11)
 set(LIBS pthread)
 
 # Source files
@@ -34,6 +36,12 @@ if (PIGPIO_LIB)
     set(LIBS ${PIGPIO_LIB} ${LIBS})
     set(SRCS ${SRCS} src/piservoorientationoutput.cpp)
 endif (PIGPIO_LIB)
+
+if (JPEG_LIB AND X11_LIB)
+    set(BUILD_FALGS -DXWIN_PRESENT=1 ${BUILD_FALGS})
+    set(LIBS ${JPEG_LIB} ${X11_LIB} ${LIBS})
+    set(SRCS ${SRCS} src/xwinframeprocessor.cpp)
+endif (JPEG_LIB AND X11_LIB)
 
 add_executable(${TGT_CAMERA_DEMO} ${SRCS})
 target_link_libraries(${TGT_CAMERA_DEMO} ${LIBS})

--- a/demos/camera_demo/src/frameprocessorcreator.hpp
+++ b/demos/camera_demo/src/frameprocessorcreator.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "fileframeprocessor.hpp"
+
+#if XWIN_PRESENT
+#include "xwinframeprocessor.hpp"
+#endif
+
+class FrameProcessorCreator {
+public:
+    enum FrameProcessorType { Filesystem, XWindows };
+
+    static FrameProcessor * get(FrameProcessorType processorType,
+        unsigned width, unsigned height, std::string outdir, bool verbose)
+    {
+        switch (processorType)
+        {
+#if XWIN_PRESENT
+            case XWindows:
+                return new XWinFrameProcessor(width, height);
+#endif
+            case Filesystem:
+            default:
+                return new FileFrameProcessor(outdir, verbose);
+        }
+    }
+};

--- a/demos/camera_demo/src/xwinframeprocessor.cpp
+++ b/demos/camera_demo/src/xwinframeprocessor.cpp
@@ -1,0 +1,131 @@
+#include <cerrno>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <iostream>
+#include "xwinframeprocessor.hpp"
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <jpeglib.h>
+
+int XWinFrameProcessor::xwinDisplayInitialize() {
+    mDisplay = XOpenDisplay(NULL);
+    if (mDisplay == NULL) {
+        std::cout << "Failed to open X display" << std::endl;
+        return -1;
+    }
+    int x_screen = DefaultScreen(mDisplay);
+    mWindow = XCreateSimpleWindow(mDisplay,
+        RootWindow(mDisplay, x_screen), 10, 10, mImageWidth, mImageHeight, 1,
+        BlackPixel(mDisplay, x_screen), WhitePixel(mDisplay, x_screen));
+    mContext = XCreateGC(mDisplay, mWindow, 0, &mContextVals);
+    mImageBuffer = (char*) calloc(mImageWidth * mImageHeight * 4, 1);
+    mJpegBuffer = (unsigned char*) calloc(mImageWidth * mImageHeight * 3, 1);
+    mJpegBufferRow = (unsigned char*) calloc(mImageWidth * 3, 1);
+    mImage = XCreateImage(mDisplay, CopyFromParent, 24, ZPixmap, 0, mImageBuffer,
+        mImageWidth, mImageHeight, 32, 4 * mImageWidth);
+    XMapWindow(mDisplay, mWindow);
+    XSync(mDisplay, 0);
+    return 0;
+}
+
+
+void XWinFrameProcessor::xwinDisplayTerminate() {
+    if (mDisplay != NULL) {
+        XDestroyImage(mImage); // frees mImageBuffer
+        XFreeGC(mDisplay, mContext);
+        XCloseDisplay(mDisplay);
+        free(mJpegBuffer);
+        free(mJpegBufferRow);
+    }
+    mImage = NULL;
+    mDisplay = NULL;
+    mImageBuffer = NULL;
+    mJpegBuffer = NULL;
+    mJpegBufferRow = NULL;
+    mContext = NULL;
+}
+
+void XWinFrameProcessor::convertJpeg(FrameBuffer buf, size_t len) {
+    int i, width, depth;
+    unsigned x, y, z, k;
+
+    struct jpeg_decompress_struct cinfo;
+    struct jpeg_error_mgr jerr;
+
+    JSAMPROW row_pointer[1];
+
+    unsigned long location = 0;
+
+    cinfo.err = jpeg_std_error(&jerr);
+
+    jpeg_create_decompress(&cinfo);
+    jpeg_mem_src(&cinfo, (unsigned char *) buf, len);
+    jpeg_read_header(&cinfo, 1);
+    cinfo.scale_num = 1;
+    cinfo.scale_denom = 1;
+
+    jpeg_start_decompress(&cinfo);
+    width = cinfo.output_width;
+    depth = cinfo.num_components; //should always be 3
+
+    row_pointer[0] = mJpegBufferRow;
+
+    while(cinfo.output_scanline < cinfo.output_height) {
+	    jpeg_read_scanlines(&cinfo, row_pointer, 1);
+	    for(i = 0; i < (width * depth); i++) {
+	        mJpegBuffer[location++] = row_pointer[0][i];
+        }
+    }
+
+    jpeg_finish_decompress(&cinfo);
+    jpeg_destroy_decompress(&cinfo);
+
+    for(z = k = y = 0; y < mImageHeight; y++) {
+	    for(x = 0; x < mImageWidth; x++) {
+		    // for 24 bit depth, organization BGRX
+            mImageBuffer[k+0]=mJpegBuffer[z+2];
+			mImageBuffer[k+1]=mJpegBuffer[z+1];
+			mImageBuffer[k+2]=mJpegBuffer[z+0];
+			k+=4; z+=3;
+		}
+	}
+}
+
+void XWinFrameProcessor::renderImage() {
+    int err;
+
+    XPutImage(mDisplay, mWindow, mContext, mImage, 0, 0, 0, 0, mImageWidth, mImageHeight);
+    err = errno;
+    XFlush(mDisplay);
+    errno = err;
+}
+
+XWinFrameProcessor::XWinFrameProcessor(unsigned width, unsigned height) :
+    mImageWidth(width), mImageHeight(height)
+{
+
+}
+
+XWinFrameProcessor::~XWinFrameProcessor()
+{
+    term();
+}
+
+int XWinFrameProcessor::init()
+{
+    return xwinDisplayInitialize();
+}
+
+void XWinFrameProcessor::term()
+{
+    xwinDisplayTerminate();
+}
+
+int XWinFrameProcessor::processFrame(FrameBuffer data, size_t length)
+{
+    convertJpeg(data, length);
+    renderImage();
+    return 0;
+}

--- a/demos/camera_demo/src/xwinframeprocessor.hpp
+++ b/demos/camera_demo/src/xwinframeprocessor.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <X11/Xlib.h>
+#include "frameprocessor.hpp"
+
+class XWinFrameProcessor : public FrameProcessor
+{
+public:
+    XWinFrameProcessor(unsigned width, unsigned height);
+    virtual ~XWinFrameProcessor();
+
+    virtual int init();
+    virtual void term();
+    virtual int processFrame(FrameBuffer data, size_t length);
+
+private:
+    unsigned       mImageWidth;
+    unsigned       mImageHeight;
+    Display*       mDisplay;
+    Window         mWindow;
+    XImage*        mImage;
+    char*          mImageBuffer;
+    unsigned char* mJpegBuffer;
+    unsigned char* mJpegBufferRow;
+    GC             mContext;
+    XGCValues      mContextVals;
+
+    int xwinDisplayInitialize();
+    void xwinDisplayTerminate();
+    void convertJpeg(FrameBuffer buf, size_t len);
+    void renderImage();
+};
+


### PR DESCRIPTION
If libjpeg and libX11 are found by CMake then frames can be displayed in an X11 window instead of saving to the filesystem.