### PR TITLE
Remove standard PanTilt.operator=

### DIFF
--- a/demos/camera_demo/src/pantilt.hpp
+++ b/demos/camera_demo/src/pantilt.hpp
@@ -26,14 +26,6 @@ class PanTilt
         PanTilt(): pan(0.0), tilt(0.0) { }
         PanTilt(float pan, float tilt): pan(pan), tilt(tilt) { }
 
-    PanTilt& operator=(const PanTilt& other) {
-        if (this != &other) {
-            this->pan = other.pan;
-            this->tilt = other.tilt;
-        }
-        return *this;
-    }
-
     PanTilt& operator+=(const PanTilt& other) {
         this->pan += other.pan;
         this->tilt += other.tilt;


### PR DESCRIPTION
This will avoid a C++ 11 deprecation warning (deprecated-copy)