### PR TITLE
camera demo implement trillium video source

### DIFF
--- a/demos/camera_demo/CMakeLists.txt
+++ b/demos/camera_demo/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SRCS
     src/baseorientationoutput.cpp
     src/remoteorientationoutput.cpp
     src/trilliumorientationoutput.cpp
+    src/trilliumutilities.cpp
     src/videosource.cpp
     src/videosensor.cpp
     src/colortracking.cpp
@@ -67,6 +68,7 @@ if (FFMPEG_LIBS)
     set(LIBS ${AVCODEC_LIB} ${AVFORMAT_LIB} ${AVUTIL_LIB} ${SWSCALE_LIB} ${LIBS})
     set(SRCS ${SRCS} src/mpeg-ts-encoder.cpp)
     set(SRCS ${SRCS} src/mpeg-ts-decoder.cpp)
+    set(SRCS ${SRCS} src/trilliumvideosource.cpp)
 else ()
     message("-- Ffmpeg libraries not found")
 endif (FFMPEG_LIBS)

--- a/demos/camera_demo/src/mpeg-ts-decoder.hpp
+++ b/demos/camera_demo/src/mpeg-ts-decoder.hpp
@@ -43,8 +43,10 @@ public:
     virtual int init() override;
     virtual void term() override;
 
-private:
+protected:
     const std::string mH264Url;
+
+private:
     int mFFmpegLogLevel;
     int mInputWidth;
     int mInputHeight;

--- a/demos/camera_demo/src/options.hpp
+++ b/demos/camera_demo/src/options.hpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-enum VideoType { VIDEO_JPEG, VIDEO_YUYV, VIDEO_H264, VIDEO_BGRX, VIDEO_STREAM, VIDEO_NULL };
+enum VideoType { VIDEO_JPEG, VIDEO_YUYV, VIDEO_H264, VIDEO_BGRX, VIDEO_STREAM, VIDEO_TRILLIUM, VIDEO_NULL };
 enum CodecType { CODEC_MPEG1, CODEC_MPEG2, CODEC_H264 };
 enum InputType { Freespace, Keyboard };
 enum FrameProcessorType { Filesystem, XWindows, H264Stream, MetaDataProcessor };

--- a/demos/camera_demo/src/optionsparser.cpp
+++ b/demos/camera_demo/src/optionsparser.cpp
@@ -41,7 +41,7 @@ static struct argp_option options[] =
 {
     { 0,              0,             0,             0, "video options:",                            1 },
     { "video_device", 'd',           "device",      0, "video device file path",                    0 },
-    { "video_type",   't',           "type",        0, "video type (jpeg|yuyv|h264|stream|none)",   0 },
+    { "video_type",   't',           "type",        0, "video type (jpeg|yuyv|h264|stream|trillium|none)", 0 },
     { "width",        'W',           "pixels",      0, "image width",                               0 },
     { "height",       'H',           "pixels",      0, "image height",                              0 },
     { "flip",         'f',           "v|h",         0, "horizontal or vertical image flip",         0 },
@@ -127,6 +127,11 @@ static error_t parseOpt(int key, char * arg, struct argp_state * state)
             else if (ss.str() == "stream")
             {
                 opt->mVideoInputType = VIDEO_STREAM;
+                opt->mVideoOutputType = VIDEO_YUYV;
+            }
+            else if (ss.str() == "trillium")
+            {
+                opt->mVideoInputType = VIDEO_TRILLIUM;
                 opt->mVideoOutputType = VIDEO_YUYV;
             }
             else if (ss.str() == "none")

--- a/demos/camera_demo/src/trilliumutilities.cpp
+++ b/demos/camera_demo/src/trilliumutilities.cpp
@@ -1,0 +1,77 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
+ */
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <string>
+#include <iostream>
+
+#include "orion-sdk/OrionPublicPacket.hpp"
+#include "orion-sdk/OrionPublicPacketShim.hpp"
+#include "orion-sdk/Constants.hpp"
+#include "orion-sdk/OrionComm.hpp"
+
+int trilliumConnectUDPSocket(std::string trilliumUrl, int& sockFd)
+{
+    std::string host = "";
+    int port = 0, rv;
+    struct sockaddr_in dest_addr;
+
+    if (trilliumUrl == "") {
+        std::cerr << "Missing required argument --trillium url" << std::endl;
+        return -1;
+    }
+
+    std::size_t found = trilliumUrl.find(':');
+
+    if (found == std::string::npos) {
+        host = trilliumUrl;
+        port = UDP_IN_PORT;
+    } else {
+        host = trilliumUrl.substr(0, found);
+        port = std::stoi(trilliumUrl.substr(found + 1));
+    }
+
+    if ((host == "") || (port == 0)) {
+        std::cerr << "unable to parse trillium url " << trilliumUrl << std::endl;
+        return -1;
+    }
+
+    std::cout << "Connecting to trillium camera at " << host << ":" << port << std::endl;
+
+    sockFd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockFd < 0) {
+        perror("Error creating socket");
+        return -1;
+    }
+
+    memset(&dest_addr, 0, sizeof(struct sockaddr_in));
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_addr.s_addr = inet_addr(host.c_str());
+    dest_addr.sin_port = htons(port);
+
+    rv = connect(sockFd, (const struct sockaddr*) &dest_addr, sizeof(struct sockaddr_in));
+    if (rv < 0) {
+        perror("Error connecting socket");
+        return -1;
+    }
+
+    return 0;
+}

--- a/demos/camera_demo/src/trilliumutilities.hpp
+++ b/demos/camera_demo/src/trilliumutilities.hpp
@@ -15,21 +15,6 @@
 
 #pragma once
 
-#include "baseorientationoutput.hpp"
+#include <string>
 
-class TrilliumOrientationOutput : public BaseOrientationOutput
-{
-public:
-    TrilliumOrientationOutput(const Options& options);
-    virtual ~TrilliumOrientationOutput();
-
-    virtual int init() override;
-    virtual void term() override;
-
-protected:
-    virtual bool applyAngularPosition(PanTilt angularPosition) override;
-
-private:
-    const std::string mTrilliumUrl;
-    int mSockFd;
-};
+int trilliumConnectUDPSocket(std::string trilliumUrl, int& sockFd);

--- a/demos/camera_demo/src/trilliumvideosource.cpp
+++ b/demos/camera_demo/src/trilliumvideosource.cpp
@@ -1,0 +1,106 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2020 Two Six Labs, LLC.  All rights reserved.
+ */
+
+#include <arpa/inet.h>
+
+#include <string>
+#include <iostream>
+
+#include "options.hpp"
+#include "trilliumvideosource.hpp"
+#include "trilliumutilities.hpp"
+
+#include "orion-sdk/OrionPublicPacket.hpp"
+#include "orion-sdk/OrionPublicPacketShim.hpp"
+#include "orion-sdk/Constants.hpp"
+#include "orion-sdk/OrionComm.hpp"
+#include "orion-sdk/fielddecode.hpp"
+
+TrilliumVideoSource::TrilliumVideoSource(const Options& options,
+        const std::vector<std::shared_ptr<FrameProcessor>>& frameProcessors) :
+    MpegTsDecoder(options, frameProcessors),
+    mTrilliumUrl(options.mTrilliumUrl),
+    mSockFd(-1)
+{
+}
+
+TrilliumVideoSource::~TrilliumVideoSource()
+{
+    term();
+}
+
+int TrilliumVideoSource::init()
+{
+    uint8_t octets[4];
+    OrionNetworkVideo_t videoSettings;
+    OrionPkt_t pktOut;
+    std::string decoderUrl = mH264Url;
+    std::string host = "";
+    int rv, port = 0;
+
+    if (decoderUrl.empty()) {
+        std::cerr << "decoder url must be specified on the command-line" << std::endl;
+        return 1;
+    }
+    if (decoderUrl.find("udp://") == 0)
+    {
+        decoderUrl = decoderUrl.substr(6);
+    }
+
+    std::size_t found = decoderUrl.find(':');
+
+    if (found == std::string::npos) {
+        std::cerr << "decoder url must be host:port" << std::endl;
+        return 1;
+    } else {
+        host = decoderUrl.substr(0, found);
+        port = std::stoi(decoderUrl.substr(found + 1));
+    }
+
+    rv = trilliumConnectUDPSocket(mTrilliumUrl, mSockFd);
+    if (rv != 0) {
+        return rv;
+    }
+
+    memset(&videoSettings, 0, sizeof(videoSettings));
+    videoSettings.Port = port;
+    videoSettings.StreamType = STREAM_TYPE_H264;
+
+    // See https://github.com/trilliumeng/orion-sdk/blob/master/Examples/VideoPlayer/VideoPlayer.c
+    if (sscanf(host.c_str(), "%3hhu.%3hhu.%3hhu.%3hhu", &octets[0], &octets[1], &octets[2], &octets[3]) != 4) {
+        std::cerr << "decoder url must be ipv4 address" << std::endl;
+        return 1;
+    }
+    int index = 0;
+    videoSettings.DestIp = uint32FromBeBytes(octets, &index);
+
+    encodeOrionNetworkVideoPacketStructure(&pktOut, &videoSettings);
+    rv = send(mSockFd, (void*) &pktOut, pktOut.Length + ORION_PKT_OVERHEAD, 0);
+    if (rv < 0) {
+        perror("Trillium video settings send command error");
+        return 1;
+    }
+
+    return MpegTsDecoder::init();
+}
+
+void TrilliumVideoSource::term()
+{
+    if (mSockFd >= 0) {
+        // TODO: can we send a command to stop the camera stream?
+        
+        close(mSockFd);
+    }
+}

--- a/demos/camera_demo/src/trilliumvideosource.hpp
+++ b/demos/camera_demo/src/trilliumvideosource.hpp
@@ -15,20 +15,28 @@
 
 #pragma once
 
-#include "baseorientationoutput.hpp"
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
 
-class TrilliumOrientationOutput : public BaseOrientationOutput
+#include <stdint.h>
+
+#include "imageconvert.hpp"
+#include "frameprocessor.hpp"
+#include "options.hpp"
+#include "videosource.hpp"
+#include "mpeg-ts-decoder.hpp"
+
+class TrilliumVideoSource : public MpegTsDecoder
 {
 public:
-    TrilliumOrientationOutput(const Options& options);
-    virtual ~TrilliumOrientationOutput();
+    TrilliumVideoSource(const Options& options,
+        const std::vector<std::shared_ptr<FrameProcessor>>& frameProcessors);
+    virtual ~TrilliumVideoSource();
 
     virtual int init() override;
     virtual void term() override;
-
-protected:
-    virtual bool applyAngularPosition(PanTilt angularPosition) override;
-
 private:
     const std::string mTrilliumUrl;
     int mSockFd;

--- a/demos/camera_demo/src/videosourcecreator.hpp
+++ b/demos/camera_demo/src/videosourcecreator.hpp
@@ -21,6 +21,7 @@
 
 #if FFMPEG_PRESENT
 #include "mpeg-ts-decoder.hpp"
+#include "trilliumvideosource.hpp"
 #endif
 
 class VideoSourceCreator {
@@ -35,6 +36,8 @@ public:
 #if FFMPEG_PRESENT
             case VIDEO_STREAM:
                 return new MpegTsDecoder(options, frameProcessors);
+            case VIDEO_TRILLIUM:
+                return new TrilliumVideoSource(options, frameProcessors);
 #endif
             case VIDEO_NULL:
                 return new VideoSource(options, frameProcessors);


### PR DESCRIPTION
The trillium video source is a derived class of the MPEG-TS decoder video source. The trillium video source sends a UDP packet to instruct the camera to start streaming and then defers processing to the MPEG-TS decoder implementation.