### PR TITLE
Bug fixes to camera flip

### DIFF
--- a/demos/camera_demo/README.md
+++ b/demos/camera_demo/README.md
@@ -91,7 +91,7 @@ Embedded application based on camera, position input and position driver
  video options:
   -d, --video_device=device  video device file path
   -D, --decoder=url          MPEG-TS H.264 decoder url (host:port)
-  -f, --flip=v|h             horizontal or vertical image flip
+  -f, --flip                 flip image and controls (rotate 180)
   -H, --height=pixels        image height
   -t, --video_type=type      video type (jpeg|yuyv|h264|stream|trillium|none)
   -W, --width=pixels         image width

--- a/demos/camera_demo/src/colortracking.cpp
+++ b/demos/camera_demo/src/colortracking.cpp
@@ -106,7 +106,7 @@ int ColorTracking::process(FrameBuffer data, size_t length, DataStreamType dataS
     if (mImageSlidingWindow) {
         PanTilt angularPosition = mCallbacks.mPosGet();
         float fractionX = (angularPosition.pan - mPanAxisMin) / (mPanAxisMax - mPanAxisMin);
-        float fractionY = (angularPosition.tilt - mTiltAxisMin) / (mTiltAxisMax - mTiltAxisMin);
+        float fractionY = (-angularPosition.tilt - mTiltAxisMin) / (mTiltAxisMax - mTiltAxisMin);
         x_center = mImageWidth * fractionX;
         y_center = mImageHeight * fractionY;
     } else {
@@ -124,9 +124,9 @@ int ColorTracking::process(FrameBuffer data, size_t length, DataStreamType dataS
     }
 
     if (y_delta > y_tolerance) {
-        update.tilt = mAngIncrement;
-    } else if (y_delta < -y_tolerance) {
         update.tilt = -mAngIncrement;
+    } else if (y_delta < -y_tolerance) {
+        update.tilt = mAngIncrement;
     }
 
     if ((update.pan != 0.0) || (update.tilt != 0.0)) {

--- a/demos/camera_demo/src/mpeg-ts-decoder.hpp
+++ b/demos/camera_demo/src/mpeg-ts-decoder.hpp
@@ -47,7 +47,8 @@ protected:
     const std::string mH264Url;
 
 private:
-    int mFFmpegLogLevel;
+    const int mFFmpegLogLevel;
+    const bool mFlip;
     int mInputWidth;
     int mInputHeight;
 
@@ -57,6 +58,7 @@ private:
     AVCodec *mCodec;
     AVCodecContext *mCodecContext;
     AVFrame *mInputFrame, *mOutputFrame;
+    uint8_t* mImageBuffer;
     struct SwsContext *mSwsContext;
     AVPacket mPkt;
     uint64_t mMetaDataBytes, mMetaDataSize;
@@ -71,7 +73,7 @@ private:
     int processDataFrame();
     int processVideoFrame();
 
-    static const AVPixelFormat YUYV_PIXEL_FORMAT = AV_PIX_FMT_YUYV422;
+    static const AVPixelFormat BGRA_PIXEL_FORMAT = AV_PIX_FMT_BGRA;
     static const AVPixelFormat H264_PIXEL_FORMAT = AV_PIX_FMT_YUV420P;
 };
 

--- a/demos/camera_demo/src/options.hpp
+++ b/demos/camera_demo/src/options.hpp
@@ -37,8 +37,7 @@ struct Options
         mEncoderCodecType(CODEC_H264),
         mImageWidth(640),
         mImageHeight(480),
-        mImageHorizontalFlip(false),
-        mImageVerticalFlip(false),
+        mImageFlip(false),
         mImageSlidingWindow(false),
         mImageTracking(false),
         mImageTrackingRGB{0, 0, 0},
@@ -78,8 +77,7 @@ struct Options
     CodecType mEncoderCodecType;
     unsigned mImageWidth;
     unsigned mImageHeight;
-    bool mImageHorizontalFlip;
-    bool mImageVerticalFlip;
+    bool mImageFlip;
     bool mImageSlidingWindow;
     bool mImageTracking;
     unsigned char mImageTrackingRGB[3];

--- a/demos/camera_demo/src/optionsparser.cpp
+++ b/demos/camera_demo/src/optionsparser.cpp
@@ -44,7 +44,7 @@ static struct argp_option options[] =
     { "video_type",   't',           "type",        0, "video type (jpeg|yuyv|h264|stream|trillium|none)", 0 },
     { "width",        'W',           "pixels",      0, "image width",                               0 },
     { "height",       'H',           "pixels",      0, "image height",                              0 },
-    { "flip",         'f',           "v|h",         0, "horizontal or vertical image flip",         0 },
+    { "flip",         'f',           NULL,          0, "flip image and controls (rotate 180)",      0 },
     { "decoder",      'D',           "url",         0, "MPEG-TS H.264 decoder url (host:port)",     0 },
     { 0,              0,             0,             0, "frame processor options:",                  2 },
     { "color_track",  'C',           "RRGGBB",      0, "color tracking (RGB hex)",                  0 },
@@ -127,12 +127,12 @@ static error_t parseOpt(int key, char * arg, struct argp_state * state)
             else if (ss.str() == "stream")
             {
                 opt->mVideoInputType = VIDEO_STREAM;
-                opt->mVideoOutputType = VIDEO_YUYV;
+                opt->mVideoOutputType = VIDEO_BGRX;
             }
             else if (ss.str() == "trillium")
             {
                 opt->mVideoInputType = VIDEO_TRILLIUM;
-                opt->mVideoOutputType = VIDEO_YUYV;
+                opt->mVideoOutputType = VIDEO_BGRX;
             }
             else if (ss.str() == "none")
             {
@@ -173,19 +173,7 @@ static error_t parseOpt(int key, char * arg, struct argp_state * state)
             break;
 
         case 'f':
-            if (ss.str() == "v")
-            {
-                opt->mImageVerticalFlip = true;
-            }
-            else if (ss.str() == "h")
-            {
-                opt->mImageHorizontalFlip = true;
-            }
-            else
-            {
-                argp_error(state, "invalid flip argument '%s'", arg);
-            }
-
+            opt->mImageFlip = true;
             break;
 
         case OPT_OUT_DIR:

--- a/demos/camera_demo/src/piservocameracontroloutput.cpp
+++ b/demos/camera_demo/src/piservocameracontroloutput.cpp
@@ -22,6 +22,7 @@
 
 PiServoCameraControlOutput::PiServoCameraControlOutput(int servoPin, const Options& options) :
     BaseCameraControlOutput(options),
+    mFlip(options.mImageFlip),
     mServoPin(servoPin),
     mGpioLibInit(true)
 {
@@ -62,7 +63,7 @@ int PiServoCameraControlOutput::init()
         return -1;
     }
 
-    rv = gpioServo(mServoPin, angleToServo(0.0));
+    rv = gpioServo(mServoPin, angleToServo(0.0, mFlip));
     if (rv != 0)
     {
         std::perror("Failed to set the initial servo position");
@@ -83,14 +84,20 @@ void PiServoCameraControlOutput::term()
     }
 }
 
-int PiServoCameraControlOutput::angleToServo(float angle)
+int PiServoCameraControlOutput::angleToServo(float angle, bool flip)
 {
     static const float slope =
         (PI_MAX_SERVO_PULSEWIDTH - PI_MIN_SERVO_PULSEWIDTH) /
         (2 * SERVO_ANGLE_LIMIT);
     static const float off = slope * SERVO_ANGLE_LIMIT + PI_MIN_SERVO_PULSEWIDTH;
-    // Fip the sign. The camera is mounted upside-down.
-    return -1.0 * slope * angle + off;
+    if (flip)
+    {
+        return -1.0 * slope * angle + off;
+    }
+    else
+    {
+        return slope * angle + off;
+    }
 }
 
 bool PiServoCameraControlOutput::equivalentPosition(PanTilt p1, PanTilt p2)
@@ -101,7 +108,7 @@ bool PiServoCameraControlOutput::equivalentPosition(PanTilt p1, PanTilt p2)
 
 bool PiServoCameraControlOutput::applyAngularPosition(PanTilt angularPosition)
 {
-    int rv = gpioServo(mServoPin, angleToServo(angularPosition.pan));
+    int rv = gpioServo(mServoPin, angleToServo(angularPosition.pan, mFlip));
 
     if (rv < 0)
     {

--- a/demos/camera_demo/src/piservocameracontroloutput.hpp
+++ b/demos/camera_demo/src/piservocameracontroloutput.hpp
@@ -32,8 +32,9 @@ protected:
     virtual bool applyAngularPosition(PanTilt angularPosition) override;
 
 private:
-    static int angleToServo(float angle);
+    static int angleToServo(float angle, bool flip);
 
+    const bool mFlip;
     const int mServoPin;
     const bool mGpioLibInit;
     static constexpr float SERVO_ANGLE_LIMIT = 90.0;

--- a/demos/camera_demo/src/trilliumcontrol.cpp
+++ b/demos/camera_demo/src/trilliumcontrol.cpp
@@ -35,8 +35,7 @@ TrilliumControl::TrilliumControl(const Options& options) :
     mVerbose(options.mVerbose),
     mReceiveThread(nullptr),
     mReceive(false),
-    mVerticalFlip(options.mImageVerticalFlip),
-    mHorizontalFlip(options.mImageHorizontalFlip)
+    mFlip(options.mImageFlip)
 {
     std::memset(&mState, 0, sizeof(mState));
 }
@@ -109,13 +108,10 @@ bool TrilliumControl::applyAngularPosition(PanTilt angularPosition)
 
     std::memset(&cmd, 0, sizeof(cmd));
     cmd.Target[0] = deg2radf(angularPosition.pan);
-    if (mHorizontalFlip)
+    cmd.Target[1] = deg2radf(angularPosition.tilt);
+    if (mFlip)
     {
         cmd.Target[0] = -cmd.Target[0];
-    }
-    cmd.Target[1] = deg2radf(angularPosition.tilt);
-    if (mVerticalFlip)
-    {
         cmd.Target[1] = -cmd.Target[1];
     }
     cmd.Mode = ORION_MODE_POSITION;

--- a/demos/camera_demo/src/trilliumcontrol.hpp
+++ b/demos/camera_demo/src/trilliumcontrol.hpp
@@ -62,6 +62,5 @@ private:
     static constexpr float mZoomMax = 8.0;
     static constexpr float mZoomDefault = mZoomMin;
 
-    const bool mVerticalFlip;
-    const bool mHorizontalFlip;
+    const bool mFlip;
 };

--- a/demos/camera_demo/src/videosensor.cpp
+++ b/demos/camera_demo/src/videosensor.cpp
@@ -41,8 +41,7 @@ VideoSensor::VideoSensor(const Options& options,
         const std::vector<std::shared_ptr<FrameProcessor>>& frameProcessors) :
     VideoSource(options, frameProcessors),
     mDevicePath(options.mVideoDevice),
-    mFlipHorizontal(options.mImageHorizontalFlip),
-    mFlipVertical(options.mImageVerticalFlip),
+    mFlip(options.mImageFlip),
     mFrameRateNumerator(options.mFrameRateNumerator),
     mFrameRateDenominator(options.mFrameRateDenominator),
     mFd(-1),
@@ -279,8 +278,19 @@ int VideoSensor::initVideoDevice()
         }
     }
 
-    // Horizontal flip
-    if (mFlipHorizontal)
+    // Reset horizontal flip. Ignore errors
+    std::memset(&ctrl, 0, sizeof(ctrl));
+    ctrl.id = V4L2_CID_HFLIP;
+    ctrl.value = 0;
+    ioctlWait(mFd, VIDIOC_S_CTRL, &ctrl);
+
+    // Reset vertical flip. Ignore errors
+    std::memset(&ctrl, 0, sizeof(ctrl));
+    ctrl.id = V4L2_CID_VFLIP;
+    ctrl.value = 0;
+    ioctlWait(mFd, VIDIOC_S_CTRL, &ctrl);
+
+    if (mFlip)
     {
         std::memset(&ctrl, 0, sizeof(ctrl));
         ctrl.id = V4L2_CID_HFLIP;
@@ -292,11 +302,7 @@ int VideoSensor::initVideoDevice()
             std::perror("V4L2: failed to set camera horizontal flip mode");
             return -1;
         }
-    }
 
-    // Vertical flip
-    if (mFlipVertical)
-    {
         std::memset(&ctrl, 0, sizeof(ctrl));
         ctrl.id = V4L2_CID_VFLIP;
         ctrl.value = 1;

--- a/demos/camera_demo/src/videosensor.hpp
+++ b/demos/camera_demo/src/videosensor.hpp
@@ -40,8 +40,7 @@ public:
 
 private:
     const std::string mDevicePath;
-    const bool mFlipHorizontal;
-    const bool mFlipVertical;
+    const bool mFlip;
     const unsigned mFrameRateNumerator;
     const unsigned mFrameRateDenominator;
 

--- a/demos/camera_demo/src/xwinframeprocessor.hpp
+++ b/demos/camera_demo/src/xwinframeprocessor.hpp
@@ -51,12 +51,9 @@ private:
     unsigned char*         mImageBuffer;
     GC                     mContext;
     XGCValues              mContextVals;
-    const bool             mImageVerticalFlip;
-    const bool             mImageHorizontalFlip;
 
     int xwinDisplayInitialize();
     void xwinDisplayTerminate();
-    int transferImageData(FrameBuffer data, size_t length);
     void slidingWindow();
     void renderImage();
 };


### PR DESCRIPTION
Use the command-line arguments to flip in the pi servo controller. Move the image flipping from the end of the pipeline to the
beginning of the pipeline. Simplify the command-line arguments use a single 'flip' argument to perform 180 degree rotation
(vertical flip and horizontal flip together).