### PR TITLE
idl refactor 'packed' from parameter into field

### DIFF
--- a/antlr/CDRBuildTypes.cpp
+++ b/antlr/CDRBuildTypes.cpp
@@ -35,7 +35,7 @@ antlrcpp::Any CDRBuildTypes::visitModule(IDLParser::ModuleContext *ctx) {
   std::string identifier = ctx->identifier()->getText();
   std::string parent = namespacePrefix.get(ctx);
   std::string newNamespace = parent + identifier + "::";
-  TypeSpec *typeSpec = new ModuleDecl(parent, identifier);
+  TypeSpec *typeSpec = new ModuleDecl(parent, identifier, packed);
   ModuleDecl *moduleDecl = dynamic_cast<ModuleDecl*>(typeSpec);
   std::vector<IDLParser::DefinitionContext*> definitions = ctx->definition();
   for (IDLParser::DefinitionContext* definitionCtx : definitions) {
@@ -234,7 +234,7 @@ antlrcpp::Any CDRBuildTypes::visitSimple_type_spec(IDLParser::Simple_type_specCo
 antlrcpp::Any CDRBuildTypes::visitEnum_type(IDLParser::Enum_typeContext *ctx) {
   std::string identifier = ctx->identifier()->getText();
   std::string parent = namespacePrefix.get(ctx);
-  TypeSpec *typeSpec = new EnumTypeSpec(parent, identifier);
+  TypeSpec *typeSpec = new EnumTypeSpec(parent, identifier, packed);
   EnumTypeSpec *enumSpec = dynamic_cast<EnumTypeSpec*>(typeSpec);
   std::vector<IDLParser::EnumeratorContext *> enumerators = ctx->enumerator();
   for (IDLParser::EnumeratorContext* enumCtx : enumerators) {
@@ -259,7 +259,7 @@ antlrcpp::Any CDRBuildTypes::visitType_decl(IDLParser::Type_declContext *ctx) {
 antlrcpp::Any CDRBuildTypes::visitStruct_type(IDLParser::Struct_typeContext *ctx) {
   std::string identifier = ctx->identifier()->getText();
   std::string parent = namespacePrefix.get(ctx);
-  TypeSpec *typeSpec = new StructTypeSpec(parent, identifier);
+  TypeSpec *typeSpec = new StructTypeSpec(parent, identifier, packed);
   StructTypeSpec *structSpec = dynamic_cast<StructTypeSpec*>(typeSpec);
   std::vector<IDLParser::MemberContext*> members = ctx->member_list()->member();
   for (IDLParser::MemberContext* memberCtx : members) {
@@ -291,7 +291,7 @@ antlrcpp::Any CDRBuildTypes::visitUnion_type(IDLParser::Union_typeContext *ctx) 
   std::string identifier = ctx->identifier()->getText();
   TypeSpec *switchType = ctx->switch_type_spec()->accept(this);
   std::string parent = namespacePrefix.get(ctx);
-  TypeSpec *typeSpec = new UnionTypeSpec(parent, identifier, switchType);
+  TypeSpec *typeSpec = new UnionTypeSpec(parent, identifier, switchType, packed);
   UnionTypeSpec *unionSpec = dynamic_cast<UnionTypeSpec*>(typeSpec);
   std::vector<IDLParser::Case_stmtContext*> members = ctx->switch_body()->case_stmt();
   for (IDLParser::Case_stmtContext* caseCtx : members) {

--- a/antlr/CDRBuildTypes.hpp
+++ b/antlr/CDRBuildTypes.hpp
@@ -24,6 +24,7 @@
 
 class CDRBuildTypes : public IDLBaseVisitor {
 private:
+  bool packed;
   antlr4::tree::ParseTreeProperty<std::string> namespacePrefix;
   std::map<std::string, TypeSpec*> typeDeclarations;
   std::set<std::string> errors;
@@ -36,8 +37,10 @@ private:
   RangeAnnotation* buildRangeAnnotation(IDLParser::Annotation_appl_paramsContext *params);
   RoundAnnotation* buildRoundAnnotation(IDLParser::Annotation_appl_paramsContext *params);
 public:
-  CDRBuildTypes() : namespacePrefix(), typeDeclarations(), errors(),
-    annotationIds(0), hasValidate(false), hasTransform(false) { }
+  CDRBuildTypes(bool packed) : packed(packed), namespacePrefix(),
+    typeDeclarations(), errors(),
+    annotationIds(0),
+    hasValidate(false), hasTransform(false) { }
   std::set<std::string> getErrors() { return errors; }
   bool hasValidateAnnotations() { return hasValidate; }
   bool hasTransformAnnotations() { return hasTransform; }

--- a/antlr/CDRGenerator.cpp
+++ b/antlr/CDRGenerator.cpp
@@ -27,7 +27,7 @@
 
 using namespace antlr4;
 
-static int generate_c(std::ostream &ostream, CDRBuildTypes &buildTypes, bool packed, ModuleDecl *moduleDecl) {
+static int generate_c(std::ostream &ostream, CDRBuildTypes &buildTypes, ModuleDecl *moduleDecl) {
     ostream << "#include <assert.h>" << std::endl;
     ostream << "#include <endian.h>" << std::endl;
     if (buildTypes.hasTransformAnnotations()) {
@@ -38,10 +38,10 @@ static int generate_c(std::ostream &ostream, CDRBuildTypes &buildTypes, bool pac
     ostream << "#include <string.h>" << std::endl;
     ostream << std::endl;
     moduleDecl->cTypeDecl(ostream);
-    moduleDecl->cTypeDeclWire(ostream, packed);
-    moduleDecl->cDeclareAsserts(ostream, packed);
-    moduleDecl->cDeclareFunctions(ostream, CDRFunc::SERIALIZE, packed);
-    moduleDecl->cDeclareFunctions(ostream, CDRFunc::DESERIALIZE, packed);
+    moduleDecl->cTypeDeclWire(ostream);
+    moduleDecl->cDeclareAsserts(ostream);
+    moduleDecl->cDeclareFunctions(ostream, CDRFunc::SERIALIZE);
+    moduleDecl->cDeclareFunctions(ostream, CDRFunc::DESERIALIZE);
     if (buildTypes.hasValidateAnnotations()) {
         moduleDecl->cDeclareAnnotationValidate(ostream);
     }
@@ -51,7 +51,7 @@ static int generate_c(std::ostream &ostream, CDRBuildTypes &buildTypes, bool pac
     return 0;
 }
 
-static int generate_cpp(std::ostream &ostream, CDRBuildTypes &buildTypes, bool packed, ModuleDecl *moduleDecl) {
+static int generate_cpp(std::ostream &ostream, CDRBuildTypes &buildTypes, ModuleDecl *moduleDecl) {
     std::string guardname = "_" + moduleDecl->identifier + "_IDL_CODEGEN_H";
     transform(guardname.begin(), guardname.end(), guardname.begin(), ::toupper);
     ostream << "#ifndef" << " " << guardname << std::endl;
@@ -66,11 +66,11 @@ static int generate_cpp(std::ostream &ostream, CDRBuildTypes &buildTypes, bool p
     ostream << "#include <endian.h>"  << std::endl;
     moduleDecl->cppDeclareHeader(ostream);
     moduleDecl->cppTypeDecl(ostream);
-    moduleDecl->cppTypeDeclWire(ostream, packed);
-    moduleDecl->cppDeclareAsserts(ostream, packed);
+    moduleDecl->cppTypeDeclWire(ostream);
+    moduleDecl->cppDeclareAsserts(ostream);
     moduleDecl->cppDeclareFooter(ostream);
     cppPirateNamespaceHeader(ostream);
-    moduleDecl->cppDeclareFunctions(ostream, packed);
+    moduleDecl->cppDeclareFunctions(ostream);
     cppPirateNamespaceFooter(ostream);
     ostream << std::endl;
     ostream << "#endif" << " " << "//" << " " << guardname << std::endl;
@@ -80,7 +80,7 @@ static int generate_cpp(std::ostream &ostream, CDRBuildTypes &buildTypes, bool p
 int parse(std::istream &istream, std::ostream &ostream, std::ostream &estream, target_t target, bool packed) {
     CDRModuleCounter moduleCounter;
     antlr4::tree::ParseTreeWalker moduleWalker;
-    CDRBuildTypes buildTypes;
+    CDRBuildTypes buildTypes(packed);
     ANTLRInputStream input(istream);
     IDLLexer lexer(&input);
     CommonTokenStream tokens(&lexer);
@@ -125,13 +125,13 @@ int parse(std::istream &istream, std::ostream &ostream, std::ostream &estream, t
 
     switch (target) {
         case TargetLanguage::C_LANG:
-            rv = generate_c(ostream, buildTypes, packed, moduleDecl);
+            rv = generate_c(ostream, buildTypes, moduleDecl);
             break;
         case TargetLanguage::CPP_LANG:
-            rv = generate_cpp(ostream, buildTypes, packed, moduleDecl);
+            rv = generate_cpp(ostream, buildTypes, moduleDecl);
             break;
         case TargetLanguage::DFDL_LANG:
-            rv = generate_dfdl(ostream, buildTypes, packed, moduleDecl);
+            rv = generate_dfdl(ostream, buildTypes, moduleDecl);
             break;
         default:
             estream << "unknown target language " << target << std::endl;

--- a/antlr/CDRTypes.cpp
+++ b/antlr/CDRTypes.cpp
@@ -131,7 +131,7 @@ void EnumTypeSpec::cppTypeDecl(std::ostream &ostream) {
     ostream << "}" << ";" << std::endl;
 }
 
-void EnumTypeSpec::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) {
+void EnumTypeSpec::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) {
     std::string funcname = identifier;
     transform(funcname.begin(), funcname.end(), funcname.begin(), ::tolower);
     ostream << std::endl;

--- a/antlr/CDRTypes.hpp
+++ b/antlr/CDRTypes.hpp
@@ -67,20 +67,20 @@ class TypeSpec {
 public:
     virtual CDRTypeOf typeOf() = 0;
     virtual void cTypeDecl(std::ostream &ostream) = 0;
-    virtual void cTypeDeclWire(std::ostream &ostream, bool packed) = 0;
+    virtual void cTypeDeclWire(std::ostream &ostream) = 0;
     virtual std::string cTypeName() = 0;
     virtual std::string cppTypeName() { return cTypeName(); }
     virtual CDRBits cTypeBits() = 0;
     virtual std::string cppNamespacePrefix() = 0;
-    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) = 0;
-    virtual void cDeclareAsserts(std::ostream &ostream, bool packed) { }
+    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) = 0;
+    virtual void cDeclareAsserts(std::ostream &ostream) { }
     virtual void cDeclareAnnotationValidate(std::ostream &ostream) = 0;
     virtual void cDeclareAnnotationTransform(std::ostream &ostream) = 0;
     virtual void cppDeclareHeader(std::ostream &ostream) { }
     virtual void cppTypeDecl(std::ostream &ostream) = 0;
-    virtual void cppTypeDeclWire(std::ostream &ostream, bool packed) = 0;
-    virtual void cppDeclareAsserts(std::ostream &ostream, bool packed) { }
-    virtual void cppDeclareFunctions(std::ostream &ostream, bool packed) = 0;
+    virtual void cppTypeDeclWire(std::ostream &ostream) = 0;
+    virtual void cppDeclareAsserts(std::ostream &ostream) { }
+    virtual void cppDeclareFunctions(std::ostream &ostream) = 0;
     virtual void cppDeclareFooter(std::ostream &ostream) { }
     virtual bool singleton() { return false; } // workaround for preventing destruction of singletons
     virtual ~TypeSpec() { };
@@ -108,15 +108,15 @@ public:
     virtual CDRTypeOf typeOf() override { return m_typeOf; }
     virtual CDRBits cTypeBits() override { return m_cTypeBits; }
     virtual void cTypeDecl(std::ostream &ostream) override { }
-    virtual void cTypeDeclWire(std::ostream &ostream, bool packed) override { }
+    virtual void cTypeDeclWire(std::ostream &ostream) override { }
     virtual std::string cTypeName() override { return m_cType; }
     virtual std::string cppNamespacePrefix() override { return ""; }
-    virtual void cDeclareFunctions(std::ostream& /*ostream*/, CDRFunc /*functionType*/, bool /* packed*/) override { };
+    virtual void cDeclareFunctions(std::ostream& /*ostream*/, CDRFunc /*functionType*/) override { };
     virtual void cDeclareAnnotationValidate(std::ostream& /*ostream*/) override { };
     virtual void cDeclareAnnotationTransform(std::ostream& /*ostream*/) override { };
     virtual void cppTypeDecl(std::ostream &ostream) override { }
-    virtual void cppTypeDeclWire(std::ostream &ostream, bool packed) override { }
-    virtual void cppDeclareFunctions(std::ostream &ostream, bool packed) override { }
+    virtual void cppTypeDeclWire(std::ostream &ostream) override { }
+    virtual void cppDeclareFunctions(std::ostream &ostream) override { }
     static TypeSpec* floatType();
     static TypeSpec* doubleType();
     static TypeSpec* longDoubleType();
@@ -140,22 +140,24 @@ class EnumTypeSpec : public TypeSpec {
 public:
     std::string namespacePrefix;
     std::string identifier;
+    bool packed;
     std::vector<std::string> enumerators;
-    EnumTypeSpec(std::string namespacePrefix, std::string identifier) :
-        namespacePrefix(namespacePrefix), identifier(identifier), enumerators() { }
+    EnumTypeSpec(std::string namespacePrefix, std::string identifier, bool packed) :
+        namespacePrefix(namespacePrefix), identifier(identifier),
+        packed(packed), enumerators() { }
     virtual CDRTypeOf typeOf() override { return CDRTypeOf::ENUM_T; }
     virtual void cTypeDecl(std::ostream &ostream) override;
-    virtual void cTypeDeclWire(std::ostream &ostream, bool packed) override { }
+    virtual void cTypeDeclWire(std::ostream &ostream) override { }
     virtual std::string cTypeName() override { return "uint32_t"; }
     virtual std::string cppTypeName() override { return identifier; }
     virtual std::string cppNamespacePrefix() override { return namespacePrefix; }
     virtual CDRBits cTypeBits() override { return CDRBits::B32; }
-    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) override;
+    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) override;
     virtual void cDeclareAnnotationValidate(std::ostream& /*ostream*/) override { };
     virtual void cDeclareAnnotationTransform(std::ostream& /*ostream*/) override { };
     virtual void cppTypeDecl(std::ostream &ostream) override;
-    virtual void cppTypeDeclWire(std::ostream &ostream, bool packed) override { }
-    virtual void cppDeclareFunctions(std::ostream &ostream, bool packed) override { }
+    virtual void cppTypeDeclWire(std::ostream &ostream) override { }
+    virtual void cppDeclareFunctions(std::ostream &ostream) override { }
     void addEnumerator(std::string enumerator);
     virtual ~EnumTypeSpec() { }
 };
@@ -179,17 +181,17 @@ public:
     TypeReference(TypeSpec *child) : child(child) { }
     virtual CDRTypeOf typeOf() override { return child->typeOf(); };
     virtual void cTypeDecl(std::ostream &ostream) override { }
-    virtual void cTypeDeclWire(std::ostream &ostream, bool packed) override { }
+    virtual void cTypeDeclWire(std::ostream &ostream) override { }
     virtual std::string cTypeName() override { return child->cTypeName(); }
     virtual std::string cppTypeName() override { return child->cppTypeName(); }
     virtual std::string cppNamespacePrefix() override { return child->cppNamespacePrefix(); }
     virtual CDRBits cTypeBits() override { return child->cTypeBits(); }
-    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) override { }
+    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) override { }
     virtual void cDeclareAnnotationValidate(std::ostream& /*ostream*/) override { }
     virtual void cDeclareAnnotationTransform(std::ostream& /*ostream*/) override { }
     virtual void cppTypeDecl(std::ostream &ostream) override { }
-    virtual void cppTypeDeclWire(std::ostream &ostream, bool packed) override { }
-    virtual void cppDeclareFunctions(std::ostream &ostream, bool packed) override { }
+    virtual void cppTypeDeclWire(std::ostream &ostream) override { }
+    virtual void cppDeclareFunctions(std::ostream &ostream) override { }
     virtual ~TypeReference() { child = nullptr; }
 };
 

--- a/antlr/DFDLGenerator.cpp
+++ b/antlr/DFDLGenerator.cpp
@@ -366,7 +366,6 @@ void construct_member(Element* e, Declarator* decl, TypeSpec* type, bool packed)
 int generate_dfdl(
     std::ostream &ostream,
     CDRBuildTypes const& buildTypes,
-    bool packed,
     ModuleDecl const* moduleDecl)
 {
     Document doc;
@@ -386,19 +385,19 @@ int generate_dfdl(
     defineFormat->SetAttribute("name", "defaults");
 
     auto defaults = add_element(defineFormat, "dfdl:format");
-    set_defaults(defaults, packed);
+    set_defaults(defaults, moduleDecl->packed);
 
     auto format = add_element(appinfo, "dfdl:format");
     format->SetAttribute("ref", "idl:defaults");
 
-    add_primitive_types(schema, packed);
+    add_primitive_types(schema, moduleDecl->packed);
 
 
     for (auto * def : moduleDecl->definitions) {
         auto name = get_type_name(def);
         auto element = add_element(schema, "xs:element");
         element->SetAttribute("name", get_type_name(def));
-        finish_type(element, def, packed);
+        finish_type(element, def, moduleDecl->packed);
     }
 
     ostream << doc;

--- a/antlr/DFDLGenerator.hpp
+++ b/antlr/DFDLGenerator.hpp
@@ -23,5 +23,4 @@
 int generate_dfdl(
     std::ostream &ostream,
     CDRBuildTypes const& buildTypes,
-    bool packed,
     ModuleDecl const* moduleDecl);

--- a/antlr/ModuleDecl.cpp
+++ b/antlr/ModuleDecl.cpp
@@ -32,15 +32,15 @@ void ModuleDecl::cppTypeDecl(std::ostream &ostream) {
     }
 }
 
-void ModuleDecl::cTypeDeclWire(std::ostream &ostream, bool packed) {
+void ModuleDecl::cTypeDeclWire(std::ostream &ostream) {
     for (TypeSpec* definition : definitions) {
-        definition->cTypeDeclWire(ostream, packed);
+        definition->cTypeDeclWire(ostream);
     }
 }
 
-void ModuleDecl::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) {
+void ModuleDecl::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) {
     for (TypeSpec* definition : definitions) {
-        definition->cDeclareFunctions(ostream, functionType, packed);
+        definition->cDeclareFunctions(ostream, functionType);
     }
 }
 
@@ -56,16 +56,16 @@ void ModuleDecl::cDeclareAnnotationTransform(std::ostream &ostream) {
     }
 }
 
-void ModuleDecl::cDeclareAsserts(std::ostream &ostream, bool packed) {
+void ModuleDecl::cDeclareAsserts(std::ostream &ostream) {
     ostream << std::endl;
     for (TypeSpec* definition : definitions) {
-        definition->cDeclareAsserts(ostream, packed);
+        definition->cDeclareAsserts(ostream);
     }
 }
 
-void ModuleDecl::cppDeclareFunctions(std::ostream &ostream, bool packed) {
+void ModuleDecl::cppDeclareFunctions(std::ostream &ostream) {
     for (TypeSpec* definition : definitions) {
-        definition->cppDeclareFunctions(ostream, packed);
+        definition->cppDeclareFunctions(ostream);
     }
 }
 

--- a/antlr/ModuleDecl.hpp
+++ b/antlr/ModuleDecl.hpp
@@ -22,24 +22,26 @@ class ModuleDecl : public TypeSpec {
 public:
     std::string namespacePrefix;
     std::string identifier;
+    bool packed;
     std::vector<TypeSpec*> definitions;
-    ModuleDecl(std::string namespacePrefix, std::string identifier) :
-        namespacePrefix(namespacePrefix), identifier(identifier), definitions() { }
+    ModuleDecl(std::string namespacePrefix, std::string identifier, bool packed) :
+        namespacePrefix(namespacePrefix), identifier(identifier),
+        packed(packed), definitions() { }
     virtual CDRTypeOf typeOf() override { return CDRTypeOf::MODULE_T; }
     virtual void cTypeDecl(std::ostream &ostream) override;
-    virtual void cTypeDeclWire(std::ostream &ostream, bool packed) override;
+    virtual void cTypeDeclWire(std::ostream &ostream) override;
     virtual std::string cTypeName() override { throw std::runtime_error("module has no type name"); }
     virtual std::string cppNamespacePrefix() override { return namespacePrefix; }
     virtual CDRBits cTypeBits() override { return CDRBits::UNDEFINED; }
-    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) override;
+    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) override;
     virtual void cDeclareAnnotationValidate(std::ostream& ostream) override;
     virtual void cDeclareAnnotationTransform(std::ostream &ostream) override;
-    virtual void cDeclareAsserts(std::ostream &ostream, bool packed) override;
+    virtual void cDeclareAsserts(std::ostream &ostream) override;
     virtual void cppDeclareHeader(std::ostream &ostream) override;
     virtual void cppTypeDecl(std::ostream &ostream) override;
-    virtual void cppTypeDeclWire(std::ostream &ostream, bool packed) override { cTypeDeclWire(ostream, packed); }
-    virtual void cppDeclareAsserts(std::ostream &ostream, bool packed) override { cDeclareAsserts(ostream, packed); }
-    virtual void cppDeclareFunctions(std::ostream &ostream, bool packed) override;
+    virtual void cppTypeDeclWire(std::ostream &ostream) override { cTypeDeclWire(ostream); }
+    virtual void cppDeclareAsserts(std::ostream &ostream) override { cDeclareAsserts(ostream); }
+    virtual void cppDeclareFunctions(std::ostream &ostream) override;
     virtual void cppDeclareFooter(std::ostream &ostream) override;
     void addDefinition(TypeSpec* definition);
     virtual ~ModuleDecl();

--- a/antlr/StructTypeSpec.cpp
+++ b/antlr/StructTypeSpec.cpp
@@ -68,7 +68,7 @@ void StructTypeSpec::cCppTypeDecl(std::ostream &ostream, bool cpp) {
     ostream << "}" << ";" << std::endl;
 }
 
-void StructTypeSpec::cTypeDeclWire(std::ostream &ostream, bool packed) {
+void StructTypeSpec::cTypeDeclWire(std::ostream &ostream) {
     ostream << std::endl;
     ostream << "struct" << " " << identifier << "_wire" << " " << "{" << std::endl;
     ostream << indent_manip::push;
@@ -103,7 +103,7 @@ void StructTypeSpec::cTypeDeclWire(std::ostream &ostream, bool packed) {
     }
 }
 
-void StructTypeSpec::cDeclareAsserts(std::ostream &ostream, bool packed) {
+void StructTypeSpec::cDeclareAsserts(std::ostream &ostream) {
     if (!packed) {
         ostream << "static_assert" << "(";
         ostream << "sizeof" << "(" << "struct" << " " << identifier << ")";
@@ -126,7 +126,7 @@ void StructTypeSpec::cDeclareFunctionApply(bool scalar, bool array, StructFuncti
     }
 }
 
-void StructTypeSpec::cCppFunctionBody(std::ostream &ostream, CDRFunc functionType, bool packed) {
+void StructTypeSpec::cCppFunctionBody(std::ostream &ostream, CDRFunc functionType) {
     cDeclareFunctionApply(true, true, [&ostream] (StructMember* member, Declarator* declarator)
         { cDeclareLocalVar(ostream, member->typeSpec, "field_" + declarator->identifier); });
     // unpacked struct types should fill the bytes of padding with 0's
@@ -146,29 +146,29 @@ void StructTypeSpec::cCppFunctionBody(std::ostream &ostream, CDRFunc functionTyp
         { cCopyMemoryOut(ostream, member->typeSpec, "field_" + declarator->identifier, declarator->identifier); });
 }
 
-void StructTypeSpec::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) {
+void StructTypeSpec::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) {
     ostream << std::endl;
     cDeclareFunctionName(ostream, functionType, identifier);
     ostream << indent_manip::push;
-    cCppFunctionBody(ostream, functionType, packed);
+    cCppFunctionBody(ostream, functionType);
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;
 }
 
-void StructTypeSpec::cppDeclareFunctions(std::ostream &ostream, bool packed) {
+void StructTypeSpec::cppDeclareFunctions(std::ostream &ostream) {
     ostream << std::endl;
     ostream << "template" << "<" << ">" << std::endl;
     ostream << "struct" << " " << "Serialization";
     ostream << "<" << "struct" << " " << namespacePrefix << identifier << ">" << " " << "{" << std::endl;
     ostream << indent_manip::push;
-    cppDeclareSerializationFunction(ostream, packed);
+    cppDeclareSerializationFunction(ostream);
     ostream << std::endl;
-    cppDeclareDeserializationFunction(ostream, packed);
+    cppDeclareDeserializationFunction(ostream);
     ostream << indent_manip::pop;
     ostream << "}" << ";" << std::endl;
 }
 
-void StructTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream, bool packed) {
+void StructTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream) {
     cppDeclareSerializationFunctionName(ostream, "struct " + namespacePrefix + identifier);
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
@@ -181,12 +181,12 @@ void StructTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream, bool
     ostream << "buf" << "." << "data" << "(" << ")" << ";" << std::endl;
     ostream << "const" << " " << "struct" << " " << namespacePrefix << identifier << "*" << " " << "input" << " ";
     ostream << "=" << " " << "&" << "val" << ";" << std::endl;
-    cCppFunctionBody(ostream, CDRFunc::SERIALIZE, packed);
+    cCppFunctionBody(ostream, CDRFunc::SERIALIZE);
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;
 }
 
-void StructTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream, bool packed) {
+void StructTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     cppDeclareDeserializationFunctionName(ostream, "struct " + namespacePrefix + identifier);
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
@@ -216,7 +216,7 @@ void StructTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream, bo
     ostream << "error_msg" << ")" << ";" << std::endl;
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;
-    cCppFunctionBody(ostream, CDRFunc::DESERIALIZE, packed);
+    cCppFunctionBody(ostream, CDRFunc::DESERIALIZE);
     ostream << "return" << " " << "retval" << ";" << std::endl;
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;

--- a/antlr/StructTypeSpec.hpp
+++ b/antlr/StructTypeSpec.hpp
@@ -32,30 +32,32 @@ typedef std::function<void(StructMember* member, Declarator* declarator)> Struct
 class StructTypeSpec : public TypeSpec {
 private:
     void cDeclareFunctionApply(bool scalar, bool array, StructFunction apply);
-    void cCppFunctionBody(std::ostream &ostream, CDRFunc functionType, bool packed);
+    void cCppFunctionBody(std::ostream &ostream, CDRFunc functionType);
     void cCppTypeDecl(std::ostream &ostream, bool cpp);
-    void cppDeclareSerializationFunction(std::ostream &ostream, bool packed);
-    void cppDeclareDeserializationFunction(std::ostream &ostream, bool packed);
+    void cppDeclareSerializationFunction(std::ostream &ostream);
+    void cppDeclareDeserializationFunction(std::ostream &ostream);
 public:
     std::string namespacePrefix;
     std::string identifier;
+    bool packed;
     std::vector<StructMember*> members;
-    StructTypeSpec(std::string namespacePrefix, std::string identifier) :
-        namespacePrefix(namespacePrefix), identifier(identifier), members() { }
+    StructTypeSpec(std::string namespacePrefix, std::string identifier, bool packed) :
+        namespacePrefix(namespacePrefix), identifier(identifier),
+        packed(packed), members() { }
     virtual CDRTypeOf typeOf() override { return CDRTypeOf::STRUCT_T; }
     virtual void cTypeDecl(std::ostream &ostream) override;
-    virtual void cTypeDeclWire(std::ostream &ostream, bool packed) override;
+    virtual void cTypeDeclWire(std::ostream &ostream) override;
     virtual std::string cTypeName() override { return "struct " + identifier; }
     virtual std::string cppNamespacePrefix() override { return namespacePrefix; }
     virtual CDRBits cTypeBits() override { return CDRBits::UNDEFINED; }
-    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) override;
+    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) override;
     virtual void cDeclareAnnotationValidate(std::ostream &ostream) override;
     virtual void cDeclareAnnotationTransform(std::ostream &ostream) override;
-    virtual void cDeclareAsserts(std::ostream &ostream, bool packed) override;
+    virtual void cDeclareAsserts(std::ostream &ostream) override;
     virtual void cppTypeDecl(std::ostream &ostream) override;
-    virtual void cppTypeDeclWire(std::ostream &ostream, bool packed) override { cTypeDeclWire(ostream, packed); }
-    virtual void cppDeclareAsserts(std::ostream &ostream, bool packed) override { cDeclareAsserts(ostream, packed); }
-    virtual void cppDeclareFunctions(std::ostream &ostream, bool packed) override;
+    virtual void cppTypeDeclWire(std::ostream &ostream) override { cTypeDeclWire(ostream); }
+    virtual void cppDeclareAsserts(std::ostream &ostream) override { cDeclareAsserts(ostream); }
+    virtual void cppDeclareFunctions(std::ostream &ostream) override;
     void addMember(StructMember* member);
     virtual ~StructTypeSpec();
 };

--- a/antlr/UnionTypeSpec.cpp
+++ b/antlr/UnionTypeSpec.cpp
@@ -73,7 +73,7 @@ void UnionTypeSpec::cCppTypeDecl(std::ostream &ostream, bool cpp) {
     ostream << "}" << ";" << std::endl;
 }
 
-void UnionTypeSpec::cTypeDeclWire(std::ostream &ostream, bool packed) {
+void UnionTypeSpec::cTypeDeclWire(std::ostream &ostream) {
     ostream << std::endl;
     ostream << "struct" << " " << identifier << "_wire" << " " << "{" << std::endl;
     ostream << indent_manip::push;
@@ -115,7 +115,7 @@ void UnionTypeSpec::cTypeDeclWire(std::ostream &ostream, bool packed) {
     }
 }
 
-void UnionTypeSpec::cDeclareAsserts(std::ostream &ostream, bool packed) {
+void UnionTypeSpec::cDeclareAsserts(std::ostream &ostream) {
     if (!packed) {
         ostream << "static_assert" << "(";
         ostream << "sizeof" << "(" << "struct" << " " << identifier << ")";
@@ -126,7 +126,7 @@ void UnionTypeSpec::cDeclareAsserts(std::ostream &ostream, bool packed) {
     }
 }
 
-void UnionTypeSpec::cCppFunctionBody(std::ostream &ostream, CDRFunc functionType, bool packed) {
+void UnionTypeSpec::cCppFunctionBody(std::ostream &ostream, CDRFunc functionType) {
     cDeclareLocalVar(ostream, switchType, "tag");
     for (UnionMember* member : members) {
         Declarator* declarator = member->declarator;
@@ -173,11 +173,11 @@ void UnionTypeSpec::cCppFunctionBody(std::ostream &ostream, CDRFunc functionType
     ostream << "}" << std::endl;
 }
 
-void UnionTypeSpec::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) {
+void UnionTypeSpec::cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) {
     ostream << std::endl;
     cDeclareFunctionName(ostream, functionType, identifier);
     ostream << indent_manip::push;
-    cCppFunctionBody(ostream, functionType, packed);
+    cCppFunctionBody(ostream, functionType);
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;
 }
@@ -249,20 +249,20 @@ void UnionTypeSpec::cDeclareAnnotationTransform(std::ostream &ostream) {
     ostream << "}" << std::endl;
 }
 
-void UnionTypeSpec::cppDeclareFunctions(std::ostream &ostream, bool packed) {
+void UnionTypeSpec::cppDeclareFunctions(std::ostream &ostream) {
     ostream << std::endl;
     ostream << "template" << "<" << ">" << std::endl;
     ostream << "struct" << " " << "Serialization";
     ostream << "<" << "struct" << " " << namespacePrefix << identifier << ">" << " " << "{" << std::endl;
     ostream << indent_manip::push;
-    cppDeclareSerializationFunction(ostream, packed);
+    cppDeclareSerializationFunction(ostream);
     ostream << std::endl;
-    cppDeclareDeserializationFunction(ostream, packed);
+    cppDeclareDeserializationFunction(ostream);
     ostream << indent_manip::pop;
     ostream << "}" << ";" << std::endl;
 }
 
-void UnionTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream, bool packed) {
+void UnionTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream) {
     cppDeclareSerializationFunctionName(ostream, "struct " + namespacePrefix + identifier);
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
@@ -275,12 +275,12 @@ void UnionTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream, bool 
     ostream << "buf" << "." << "data" << "(" << ")" << ";" << std::endl;
     ostream << "const" << " " << "struct" << " " << namespacePrefix << identifier << "*" << " " << "input" << " ";
     ostream << "=" << " " << "&" << "val" << ";" << std::endl;
-    cCppFunctionBody(ostream, CDRFunc::SERIALIZE, packed);
+    cCppFunctionBody(ostream, CDRFunc::SERIALIZE);
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;
 }
 
-void UnionTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream, bool packed) {
+void UnionTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     cppDeclareDeserializationFunctionName(ostream, "struct " + namespacePrefix + identifier);
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
@@ -310,7 +310,7 @@ void UnionTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream, boo
     ostream << "error_msg" << ")" << ";" << std::endl;
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;
-    cCppFunctionBody(ostream, CDRFunc::DESERIALIZE, packed);
+    cCppFunctionBody(ostream, CDRFunc::DESERIALIZE);
     ostream << "return" << " " << "retval" << ";" << std::endl;
     ostream << indent_manip::pop;
     ostream << "}" << std::endl;

--- a/antlr/UnionTypeSpec.hpp
+++ b/antlr/UnionTypeSpec.hpp
@@ -34,32 +34,33 @@ public:
 // Implementation of the union type
 class UnionTypeSpec : public TypeSpec {
 private:
-    void cCppFunctionBody(std::ostream &ostream, CDRFunc functionType, bool packed);
+    void cCppFunctionBody(std::ostream &ostream, CDRFunc functionType);
     void cCppTypeDecl(std::ostream &ostream, bool cpp);
-    void cppDeclareSerializationFunction(std::ostream &ostream, bool packed);
-    void cppDeclareDeserializationFunction(std::ostream &ostream, bool packed);
+    void cppDeclareSerializationFunction(std::ostream &ostream);
+    void cppDeclareDeserializationFunction(std::ostream &ostream);
 public:
     std::string namespacePrefix;
     std::string identifier;
     TypeSpec* switchType;
+    bool packed;
     std::vector<UnionMember*> members;
-    UnionTypeSpec(std::string namespacePrefix, std::string identifier, TypeSpec *switchType) :
+    UnionTypeSpec(std::string namespacePrefix, std::string identifier, TypeSpec *switchType, bool packed) :
         namespacePrefix(namespacePrefix), identifier(identifier),
-        switchType(switchType), members() { }
+        switchType(switchType), packed(packed), members() { }
     virtual CDRTypeOf typeOf() override { return CDRTypeOf::UNION_T; }
     virtual void cTypeDecl(std::ostream &ostream) override;
-    virtual void cTypeDeclWire(std::ostream &ostream, bool packed) override;
+    virtual void cTypeDeclWire(std::ostream &ostream) override;
     virtual std::string cTypeName() override { return "struct " + identifier; }
     virtual std::string cppNamespacePrefix() override { return namespacePrefix; }
     virtual CDRBits cTypeBits() override { return CDRBits::UNDEFINED; }
-    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType, bool packed) override;
+    virtual void cDeclareFunctions(std::ostream &ostream, CDRFunc functionType) override;
     virtual void cDeclareAnnotationValidate(std::ostream& ostream) override;
     virtual void cDeclareAnnotationTransform(std::ostream &ostream) override;
-    virtual void cDeclareAsserts(std::ostream &ostream, bool packed) override;
+    virtual void cDeclareAsserts(std::ostream &ostream) override;
     virtual void cppTypeDecl(std::ostream &ostream) override;
-    virtual void cppTypeDeclWire(std::ostream &ostream, bool packed) override { cTypeDeclWire(ostream, packed); }
-    virtual void cppDeclareAsserts(std::ostream &ostream, bool packed) override { cDeclareAsserts(ostream, packed); }
-    virtual void cppDeclareFunctions(std::ostream &ostream, bool packed) override;
+    virtual void cppTypeDeclWire(std::ostream &ostream) override { cTypeDeclWire(ostream); }
+    virtual void cppDeclareAsserts(std::ostream &ostream) override { cDeclareAsserts(ostream); }
+    virtual void cppDeclareFunctions(std::ostream &ostream) override;
     void addMember(UnionMember* member);
     virtual ~UnionTypeSpec();
 };


### PR DESCRIPTION
Refactor the 'packed' boolean from a function parameter into a class field. The first implementation was quick and dirty and just passed around the 'packed' boolean wherever it was needed.