### PR TITLE
idl code generation bug fixes

### DIFF
--- a/antlr/CDRBuildTypes.cpp
+++ b/antlr/CDRBuildTypes.cpp
@@ -327,8 +327,6 @@ antlrcpp::Any CDRBuildTypes::visitCase_stmt(IDLParser::Case_stmtContext *ctx) {
   for (IDLParser::Case_labelContext* labelCtx : labels) {
     if (labelCtx->const_exp() == nullptr) {
       member->setHasDefault();
-    } else if (labelCtx->const_exp()->scoped_name() != nullptr) {
-      member->addLabel(typeSpec->cppNamespacePrefix() + labelCtx->const_exp()->getText());
     } else {
       member->addLabel(labelCtx->const_exp()->getText());
     }

--- a/antlr/DFDLGenerator.cpp
+++ b/antlr/DFDLGenerator.cpp
@@ -223,13 +223,13 @@ std::string
 get_type_name(TypeSpec* typeSpec)
 {
     if (auto * p = dynamic_cast<StructTypeSpec*>(typeSpec)) {
-        return p->identifier + "Type";
+        return p->identifier;
     } else if (auto * p = dynamic_cast<UnionTypeSpec*>(typeSpec)) {
-        return p->identifier + "Type";
+        return p->identifier;
     } else if (auto * p = dynamic_cast<TypeReference*>(typeSpec)) {
         return get_type_name(p->child);
     } else if (auto * p = dynamic_cast<EnumTypeSpec*>(typeSpec)) {
-        return p->identifier + "Type";
+        return p->identifier;
     } else if (NULL != dynamic_cast<BaseTypeSpec*>(typeSpec)) {
         not_implemented("get_type_name of base type");
     } else {
@@ -379,7 +379,7 @@ declare_top_type(Element* schema, TypeSpec* typeSpec, bool packed)
                 }
             }
             auto elem = add_element(schema, "xs:element");
-            elem->SetAttribute("name", s->identifier);
+            elem->SetAttribute("name", s->identifier + "Decl");
             elem->SetAttribute("type", "idl:" + get_type_name(typeSpec));
             break;
         }
@@ -424,7 +424,7 @@ declare_top_type(Element* schema, TypeSpec* typeSpec, bool packed)
                 construct_member(member, m->declarator, m->typeSpec, packed);
             }
             auto elem = add_element(schema, "xs:element");
-            elem->SetAttribute("name", u->identifier);
+            elem->SetAttribute("name", u->identifier + "Decl");
             elem->SetAttribute("type", "idl:" + get_type_name(typeSpec));
             break;
         }
@@ -437,7 +437,7 @@ declare_top_type(Element* schema, TypeSpec* typeSpec, bool packed)
             // should we declare an element for this enum?
             // auto ets = static_cast<EnumTypeSpec*>(typeSpec);
             // auto elem = add_element(schema, "xs:element");
-            // elem->SetAttribute("name", ets->identifier);
+            // elem->SetAttribute("name", ets->identifier + "Decl");
             // elem->SetAttribute("type", "idl:" + get_type_name(typeSpec));
             break;
         }

--- a/antlr/DFDLGenerator.cpp
+++ b/antlr/DFDLGenerator.cpp
@@ -322,13 +322,13 @@ finish_inner_type(Element* e, Declarator* decl, TypeSpec* typeSpec, bool packed)
     }
     switch (typeSpec->typeOf()) {
         case CDRTypeOf::STRUCT_T:
-            not_implemented("finish_inner_type should not be called on struct");
+            not_implemented("finish_inner_type of struct");
             break;
         case CDRTypeOf::UNION_T:
-            not_implemented("finish_inner_type should not be called on union");
+            not_implemented("finish_inner_type of union");
             break;
         case CDRTypeOf::ENUM_T:
-            not_implemented("finish_inner_type should not be called on enum");
+            not_implemented("finish_inner_type of enum");
             break;
         default:
             break;
@@ -440,7 +440,7 @@ declare_top_type(Element* schema, TypeSpec* typeSpec, bool packed)
             break;
         }
         default:
-            not_implemented("invalid top level type");
+            not_implemented("declare_top_type on inner type");
             break;
     }
 

--- a/antlr/DFDLGenerator.cpp
+++ b/antlr/DFDLGenerator.cpp
@@ -435,8 +435,10 @@ declare_top_type(Element* schema, TypeSpec* typeSpec, bool packed)
             auto rest = add_element(simple, "xs:restriction");
             rest->SetAttribute("base", "idl:uint32");
             // should we declare an element for this enum?
+            // auto ets = static_cast<EnumTypeSpec*>(typeSpec);
             // auto elem = add_element(schema, "xs:element");
-            // elem->SetAttribute("type", ets->identifier);
+            // elem->SetAttribute("name", ets->identifier);
+            // elem->SetAttribute("type", "idl:" + get_type_name(typeSpec));
             break;
         }
         default:

--- a/antlr/DFDLGenerator.cpp
+++ b/antlr/DFDLGenerator.cpp
@@ -223,13 +223,13 @@ std::string
 get_type_name(TypeSpec* typeSpec)
 {
     if (auto * p = dynamic_cast<StructTypeSpec*>(typeSpec)) {
-        return p->identifier;
+        return p->identifier + "Type";
     } else if (auto * p = dynamic_cast<UnionTypeSpec*>(typeSpec)) {
-        return p->identifier;
+        return p->identifier + "Type";
     } else if (auto * p = dynamic_cast<TypeReference*>(typeSpec)) {
         return get_type_name(p->child);
     } else if (auto * p = dynamic_cast<EnumTypeSpec*>(typeSpec)) {
-        return p->identifier;
+        return p->identifier + "Type";
     } else if (NULL != dynamic_cast<BaseTypeSpec*>(typeSpec)) {
         not_implemented("get_type_name of base type");
     } else {
@@ -276,7 +276,7 @@ construct_type(TypeSpec* typeSpec)
         case CDRTypeOf::UNION_T:
             not_implemented("construct_type of union");
         case CDRTypeOf::ENUM_T:
-            return "idl:uint32";
+            not_implemented("construct_type of enum");
         case CDRTypeOf::LONG_DOUBLE_T:
             not_implemented("construct_type of long double");
         case CDRTypeOf::ERROR_T:
@@ -313,21 +313,61 @@ construct_type(TypeSpec* typeSpec)
 }
 
 void
-finish_type(Element* e, Declarator* decl, TypeSpec* typeSpec, bool packed)
+finish_inner_type(Element* e, Declarator* decl, TypeSpec* typeSpec, bool packed)
 {
     bool nestedType = false;
     if (auto * typeref = dynamic_cast<TypeReference*>(typeSpec)) {
-        e->SetAttribute("ref", "idl:" + get_type_name(typeref->child));
-        e->RemoveAttribute("name");
+        e->SetAttribute("type", "idl:" + get_type_name(typeref));
         return;
     }
+    switch (typeSpec->typeOf()) {
+        case CDRTypeOf::STRUCT_T:
+            not_implemented("finish_inner_type should not be called on struct");
+            break;
+        case CDRTypeOf::UNION_T:
+            not_implemented("finish_inner_type should not be called on union");
+            break;
+        case CDRTypeOf::ENUM_T:
+            not_implemented("finish_inner_type should not be called on enum");
+            break;
+        default:
+            break;
+    }
+    if (decl != nullptr) {
+        for (auto ann : decl->annotations) {
+            if (dynamic_cast<ValueAnnotation*>(ann) == nullptr) {
+                nestedType = true;
+            }
+        }
+    }
+    if (!nestedType) {
+        e->SetAttribute("type", construct_type(typeSpec));
+    } else {
+        auto st = add_element(e, "xs:simpleType");
+        auto restrict = add_element(st, "xs:restriction");
+        restrict->SetAttribute("base", construct_type(typeSpec));
+        if (decl != nullptr) {
+            for (auto ann : decl->annotations) {
+                if (auto * rangeAnn = dynamic_cast<RangeAnnotation*>(ann)) {
+                    add_element(restrict, "xs:minInclusive")->SetAttribute("value", rangeAnn->min);
+                    add_element(restrict, "xs:maxInclusive")->SetAttribute("value", rangeAnn->max);
+                }
+            }
+        }
+    }
+}
 
+
+void
+declare_top_type(Element* schema, TypeSpec* typeSpec, bool packed)
+{
     switch (typeSpec->typeOf()) {
         case CDRTypeOf::STRUCT_T:
         {
             auto s = static_cast<StructTypeSpec const*>(typeSpec);
 
-            auto complex = add_element(e, "xs:complexType");
+            auto complex = add_element(schema, "xs:complexType");
+            complex->SetAttribute("name", get_type_name(typeSpec));
             auto sequence = add_element(complex, "xs:sequence");
 
             for (auto m : s->members) {
@@ -338,18 +378,22 @@ finish_type(Element* e, Declarator* decl, TypeSpec* typeSpec, bool packed)
                     construct_member(member, d, m->typeSpec, packed);
                 }
             }
-            return;
+            auto elem = add_element(schema, "xs:element");
+            elem->SetAttribute("name", s->identifier);
+            elem->SetAttribute("type", "idl:" + get_type_name(typeSpec));
+            break;
         }
         case CDRTypeOf::UNION_T:
         {
             auto u = static_cast<UnionTypeSpec*>(typeSpec);
 
-            auto complex = add_element(e, "xs:complexType");
+            auto complex = add_element(schema, "xs:complexType");
+            complex->SetAttribute("name", get_type_name(typeSpec));
             auto sequence = add_element(complex, "xs:sequence");
 
             auto tag = add_element(sequence, "xs:element");
             tag->SetAttribute("name", "tag");
-            finish_type(tag, nullptr, u->switchType, packed);
+            finish_inner_type(tag, nullptr, u->switchType, packed);
 
             auto data = add_element(sequence, "xs:element");
             data->SetAttribute("name", "data");
@@ -379,36 +423,28 @@ finish_type(Element* e, Declarator* decl, TypeSpec* typeSpec, bool packed)
 
                 construct_member(member, m->declarator, m->typeSpec, packed);
             }
-            return;
+            auto elem = add_element(schema, "xs:element");
+            elem->SetAttribute("name", u->identifier);
+            elem->SetAttribute("type", "idl:" + get_type_name(typeSpec));
+            break;
+        }
+        case CDRTypeOf::ENUM_T:
+        {
+            auto simple = add_element(schema, "xs:simpleType");
+            simple->SetAttribute("name", get_type_name(typeSpec));
+            auto rest = add_element(simple, "xs:restriction");
+            rest->SetAttribute("base", "idl:uint32");
+            // should we declare an element for this enum?
+            // auto elem = add_element(schema, "xs:element");
+            // elem->SetAttribute("type", ets->identifier);
+            break;
         }
         default:
-            // do nothing
+            not_implemented("invalid top level type");
             break;
     }
 
-    if (decl != nullptr) {
-        for (auto ann : decl->annotations) {
-            if (dynamic_cast<ValueAnnotation*>(ann) == nullptr) {
-                nestedType = true;
-            }
-        }
-    }
 
-    if (!nestedType) {
-        e->SetAttribute("type", construct_type(typeSpec));
-    } else {
-        auto st = add_element(e, "xs:simpleType");
-        auto restrict = add_element(st, "xs:restriction");
-        restrict->SetAttribute("base", construct_type(typeSpec));
-        if (decl != nullptr) {
-            for (auto ann : decl->annotations) {
-                if (auto * rangeAnn = dynamic_cast<RangeAnnotation*>(ann)) {
-                    add_element(restrict, "xs:minInclusive")->SetAttribute("value", rangeAnn->min);
-                    add_element(restrict, "xs:maxInclusive")->SetAttribute("value", rangeAnn->max);
-                }
-            }
-        }
-    }
 }
 
 void construct_member(Element* e, Declarator* decl, TypeSpec* type, bool packed)
@@ -428,7 +464,7 @@ void construct_member(Element* e, Declarator* decl, TypeSpec* type, bool packed)
         }
     }
 
-    finish_type(e, decl, type, packed);
+    finish_inner_type(e, decl, type, packed);
 }
 
 }
@@ -462,12 +498,8 @@ int generate_dfdl(
 
     add_primitive_types(schema, moduleDecl->packed);
 
-
     for (auto * def : moduleDecl->definitions) {
-        auto name = get_type_name(def);
-        auto element = add_element(schema, "xs:element");
-        element->SetAttribute("name", get_type_name(def));
-        finish_type(element, nullptr, def, moduleDecl->packed);
+        declare_top_type(schema, def, moduleDecl->packed);
     }
     ostream << "<!--" << std::endl;
     ostream << license_header << std::endl;

--- a/antlr/UnionTypeSpec.cpp
+++ b/antlr/UnionTypeSpec.cpp
@@ -154,8 +154,11 @@ void UnionTypeSpec::cCppFunctionBody(std::ostream &ostream, CDRFunc functionType
         ostream << "switch" << " " << "(" << "output" << "->" << "tag" << ")" << " " << "{" << std::endl;
     }
     for (UnionMember* member : members) {
-         Declarator* declarator = member->declarator;
+        Declarator* declarator = member->declarator;
         for (std::string label : member->labels) {
+            if ((switchType->typeOf() == CDRTypeOf::ENUM_T) && (languageType == TargetLanguage::CPP_LANG)) {
+                label = switchType->cppNamespacePrefix() + switchType->cppTypeName() + "::" + label;
+            }
             ostream << "case" << " " << label << ":" << std::endl;
         }
         if (member->hasDefault) {

--- a/antlr/test/input/nested.idl
+++ b/antlr/test/input/nested.idl
@@ -9,12 +9,14 @@ module NestedTypes {
     Foo foo;
     Bar bar;
   };
-  union OuterUnion switch (short) { 
-    case 1:
-    case 2:
-    case 3:
+  enum DayOfWeek { Monday, Tuesday, Wednesday, Thursday, Friday };
+  union OuterUnion switch (DayOfWeek) {
+    case Monday:
+    case Tuesday:
+    case Wednesday:
       Foo foo;
-    default:
+    case Thursday:
+    case Friday:
       Bar bar;
   };
 };

--- a/antlr/test/output/c/nested.c
+++ b/antlr/test/output/c/nested.c
@@ -21,8 +21,16 @@ struct OuterStruct {
 	struct Bar bar;
 };
 
+enum DayOfWeek {
+	Monday,
+	Tuesday,
+	Wednesday,
+	Thursday,
+	Friday
+};
+
 struct OuterUnion {
-	int16_t tag __attribute__((aligned(2)));
+	uint32_t tag __attribute__((aligned(4)));
 	union {
 		struct Foo foo;
 		struct Bar bar;
@@ -47,7 +55,7 @@ struct OuterStruct_wire {
 };
 
 struct OuterUnion_wire {
-	unsigned char tag[2];
+	unsigned char tag[4];
 	union {
 		struct Foo_wire foo;
 		struct Bar_wire bar;
@@ -98,19 +106,25 @@ void encode_outerstruct(struct OuterStruct* input, struct OuterStruct_wire* outp
 	encode_bar(&input->bar, &output->bar);
 }
 
+uint32_t encode_dayofweek(uint32_t value) {
+	value = htobe32(value);
+	return value;
+}
+
 void encode_outerunion(struct OuterUnion* input, struct OuterUnion_wire* output) {
-	uint16_t tag;
+	uint32_t tag;
 	memset(output, 0, sizeof(*output));
-	memcpy(&tag, &input->tag, sizeof(uint16_t));
-	tag = htobe16(tag);
-	memcpy(&output->tag, &tag, sizeof(uint16_t));
+	memcpy(&tag, &input->tag, sizeof(uint32_t));
+	tag = htobe32(tag);
+	memcpy(&output->tag, &tag, sizeof(uint32_t));
 	switch (input->tag) {
-	case 1:
-	case 2:
-	case 3:
+	case Monday:
+	case Tuesday:
+	case Wednesday:
 		encode_foo(&input->data.foo, &output->data.foo);
 		break;
-	default:
+	case Thursday:
+	case Friday:
 		encode_bar(&input->data.bar, &output->data.bar);
 		break;
 	}
@@ -151,18 +165,24 @@ void decode_outerstruct(struct OuterStruct_wire* input, struct OuterStruct* outp
 	decode_bar(&input->bar, &output->bar);
 }
 
+uint32_t decode_dayofweek(uint32_t value) {
+	value = be32toh(value);
+	return value;
+}
+
 void decode_outerunion(struct OuterUnion_wire* input, struct OuterUnion* output) {
-	uint16_t tag;
-	memcpy(&tag, &input->tag, sizeof(uint16_t));
-	tag = be16toh(tag);
-	memcpy(&output->tag, &tag, sizeof(uint16_t));
+	uint32_t tag;
+	memcpy(&tag, &input->tag, sizeof(uint32_t));
+	tag = be32toh(tag);
+	memcpy(&output->tag, &tag, sizeof(uint32_t));
 	switch (output->tag) {
-	case 1:
-	case 2:
-	case 3:
+	case Monday:
+	case Tuesday:
+	case Wednesday:
 		decode_foo(&input->data.foo, &output->data.foo);
 		break;
-	default:
+	case Thursday:
+	case Friday:
 		decode_bar(&input->data.bar, &output->data.bar);
 		break;
 	}

--- a/antlr/test/output/c/packed/nested.c
+++ b/antlr/test/output/c/packed/nested.c
@@ -21,8 +21,16 @@ struct OuterStruct {
 	struct Bar bar;
 };
 
+enum DayOfWeek {
+	Monday,
+	Tuesday,
+	Wednesday,
+	Thursday,
+	Friday
+};
+
 struct OuterUnion {
-	int16_t tag __attribute__((aligned(2)));
+	uint32_t tag __attribute__((aligned(4)));
 	union {
 		struct Foo foo;
 		struct Bar bar;
@@ -47,7 +55,7 @@ struct OuterStruct_wire {
 } __attribute__((packed)) ;
 
 struct OuterUnion_wire {
-	unsigned char tag[2];
+	unsigned char tag[4];
 	union {
 		struct Foo_wire foo;
 		struct Bar_wire bar;
@@ -90,19 +98,25 @@ void encode_outerstruct(struct OuterStruct* input, struct OuterStruct_wire* outp
 	encode_bar(&input->bar, &output->bar);
 }
 
+uint32_t encode_dayofweek(uint32_t value) {
+	value = htobe32(value);
+	return value;
+}
+
 void encode_outerunion(struct OuterUnion* input, struct OuterUnion_wire* output) {
-	uint16_t tag;
+	uint32_t tag;
 	memset(output, 0, sizeof(*output));
-	memcpy(&tag, &input->tag, sizeof(uint16_t));
-	tag = htobe16(tag);
-	memcpy(&output->tag, &tag, sizeof(uint16_t));
+	memcpy(&tag, &input->tag, sizeof(uint32_t));
+	tag = htobe32(tag);
+	memcpy(&output->tag, &tag, sizeof(uint32_t));
 	switch (input->tag) {
-	case 1:
-	case 2:
-	case 3:
+	case Monday:
+	case Tuesday:
+	case Wednesday:
 		encode_foo(&input->data.foo, &output->data.foo);
 		break;
-	default:
+	case Thursday:
+	case Friday:
 		encode_bar(&input->data.bar, &output->data.bar);
 		break;
 	}
@@ -143,18 +157,24 @@ void decode_outerstruct(struct OuterStruct_wire* input, struct OuterStruct* outp
 	decode_bar(&input->bar, &output->bar);
 }
 
+uint32_t decode_dayofweek(uint32_t value) {
+	value = be32toh(value);
+	return value;
+}
+
 void decode_outerunion(struct OuterUnion_wire* input, struct OuterUnion* output) {
-	uint16_t tag;
-	memcpy(&tag, &input->tag, sizeof(uint16_t));
-	tag = be16toh(tag);
-	memcpy(&output->tag, &tag, sizeof(uint16_t));
+	uint32_t tag;
+	memcpy(&tag, &input->tag, sizeof(uint32_t));
+	tag = be32toh(tag);
+	memcpy(&output->tag, &tag, sizeof(uint32_t));
 	switch (output->tag) {
-	case 1:
-	case 2:
-	case 3:
+	case Monday:
+	case Tuesday:
+	case Wednesday:
 		decode_foo(&input->data.foo, &output->data.foo);
 		break;
-	default:
+	case Thursday:
+	case Friday:
 		decode_bar(&input->data.bar, &output->data.bar);
 		break;
 	}

--- a/antlr/test/output/cpp/nested.cpp
+++ b/antlr/test/output/cpp/nested.cpp
@@ -28,8 +28,16 @@ namespace NestedTypes {
 		struct Bar bar;
 	};
 
+	enum class DayOfWeek : uint32_t {
+		Monday,
+		Tuesday,
+		Wednesday,
+		Thursday,
+		Friday
+	};
+
 	struct OuterUnion {
-		int16_t tag __attribute__((aligned(2)));
+		DayOfWeek tag __attribute__((aligned(4)));
 		union {
 			struct Foo foo;
 			struct Bar bar;
@@ -54,7 +62,7 @@ namespace NestedTypes {
 	};
 
 	struct OuterUnion_wire {
-		unsigned char tag[2];
+		unsigned char tag[4];
 		union {
 			struct Foo_wire foo;
 			struct Bar_wire bar;
@@ -224,18 +232,19 @@ namespace pirate {
 	};
 
 	inline void toWireType(const struct NestedTypes::OuterUnion* input, struct NestedTypes::OuterUnion_wire* output) {
-		uint16_t tag;
+		uint32_t tag;
 		memset(output, 0, sizeof(*output));
-		memcpy(&tag, &input->tag, sizeof(uint16_t));
-		tag = htobe16(tag);
-		memcpy(&output->tag, &tag, sizeof(uint16_t));
+		memcpy(&tag, &input->tag, sizeof(uint32_t));
+		tag = htobe32(tag);
+		memcpy(&output->tag, &tag, sizeof(uint32_t));
 		switch (input->tag) {
-		case 1:
-		case 2:
-		case 3:
+		case NestedTypes::DayOfWeek::Monday:
+		case NestedTypes::DayOfWeek::Tuesday:
+		case NestedTypes::DayOfWeek::Wednesday:
 			toWireType(&input->data.foo, &output->data.foo);
 			break;
-		default:
+		case NestedTypes::DayOfWeek::Thursday:
+		case NestedTypes::DayOfWeek::Friday:
 			toWireType(&input->data.bar, &output->data.bar);
 			break;
 		}
@@ -244,17 +253,18 @@ namespace pirate {
 	inline struct NestedTypes::OuterUnion fromWireType(const struct NestedTypes::OuterUnion_wire* input) {
 		struct NestedTypes::OuterUnion retval;
 		struct NestedTypes::OuterUnion* output = &retval;
-		uint16_t tag;
-		memcpy(&tag, &input->tag, sizeof(uint16_t));
-		tag = be16toh(tag);
-		memcpy(&output->tag, &tag, sizeof(uint16_t));
+		uint32_t tag;
+		memcpy(&tag, &input->tag, sizeof(uint32_t));
+		tag = be32toh(tag);
+		memcpy(&output->tag, &tag, sizeof(uint32_t));
 		switch (output->tag) {
-		case 1:
-		case 2:
-		case 3:
+		case NestedTypes::DayOfWeek::Monday:
+		case NestedTypes::DayOfWeek::Tuesday:
+		case NestedTypes::DayOfWeek::Wednesday:
 			output->data.foo = fromWireType(&input->data.foo);
 			break;
-		default:
+		case NestedTypes::DayOfWeek::Thursday:
+		case NestedTypes::DayOfWeek::Friday:
 			output->data.bar = fromWireType(&input->data.bar);
 			break;
 		}

--- a/antlr/test/output/cpp/packed/nested.cpp
+++ b/antlr/test/output/cpp/packed/nested.cpp
@@ -28,8 +28,16 @@ namespace NestedTypes {
 		struct Bar bar;
 	};
 
+	enum class DayOfWeek : uint32_t {
+		Monday,
+		Tuesday,
+		Wednesday,
+		Thursday,
+		Friday
+	};
+
 	struct OuterUnion {
-		int16_t tag __attribute__((aligned(2)));
+		DayOfWeek tag __attribute__((aligned(4)));
 		union {
 			struct Foo foo;
 			struct Bar bar;
@@ -54,7 +62,7 @@ namespace NestedTypes {
 	} __attribute__((packed)) ;
 
 	struct OuterUnion_wire {
-		unsigned char tag[2];
+		unsigned char tag[4];
 		union {
 			struct Foo_wire foo;
 			struct Bar_wire bar;
@@ -216,18 +224,19 @@ namespace pirate {
 	};
 
 	inline void toWireType(const struct NestedTypes::OuterUnion* input, struct NestedTypes::OuterUnion_wire* output) {
-		uint16_t tag;
+		uint32_t tag;
 		memset(output, 0, sizeof(*output));
-		memcpy(&tag, &input->tag, sizeof(uint16_t));
-		tag = htobe16(tag);
-		memcpy(&output->tag, &tag, sizeof(uint16_t));
+		memcpy(&tag, &input->tag, sizeof(uint32_t));
+		tag = htobe32(tag);
+		memcpy(&output->tag, &tag, sizeof(uint32_t));
 		switch (input->tag) {
-		case 1:
-		case 2:
-		case 3:
+		case NestedTypes::DayOfWeek::Monday:
+		case NestedTypes::DayOfWeek::Tuesday:
+		case NestedTypes::DayOfWeek::Wednesday:
 			toWireType(&input->data.foo, &output->data.foo);
 			break;
-		default:
+		case NestedTypes::DayOfWeek::Thursday:
+		case NestedTypes::DayOfWeek::Friday:
 			toWireType(&input->data.bar, &output->data.bar);
 			break;
 		}
@@ -236,17 +245,18 @@ namespace pirate {
 	inline struct NestedTypes::OuterUnion fromWireType(const struct NestedTypes::OuterUnion_wire* input) {
 		struct NestedTypes::OuterUnion retval;
 		struct NestedTypes::OuterUnion* output = &retval;
-		uint16_t tag;
-		memcpy(&tag, &input->tag, sizeof(uint16_t));
-		tag = be16toh(tag);
-		memcpy(&output->tag, &tag, sizeof(uint16_t));
+		uint32_t tag;
+		memcpy(&tag, &input->tag, sizeof(uint32_t));
+		tag = be32toh(tag);
+		memcpy(&output->tag, &tag, sizeof(uint32_t));
 		switch (output->tag) {
-		case 1:
-		case 2:
-		case 3:
+		case NestedTypes::DayOfWeek::Monday:
+		case NestedTypes::DayOfWeek::Tuesday:
+		case NestedTypes::DayOfWeek::Wednesday:
 			output->data.foo = fromWireType(&input->data.foo);
 			break;
-		default:
+		case NestedTypes::DayOfWeek::Thursday:
+		case NestedTypes::DayOfWeek::Friday:
 			output->data.bar = fromWireType(&input->data.bar);
 			break;
 		}

--- a/antlr/test/output/dfdl/nested.dfdl.xsd
+++ b/antlr/test/output/dfdl/nested.dfdl.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:idl="urn:idl:1.0" targetNamespace="urn:idl:1.0">
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineFormat name="defaults">
+        <dfdl:format alignmentUnits="bits" binaryBooleanFalseRep="0" binaryBooleanTrueRep="1" binaryFloatRep="ieee" binaryNumberCheckPolicy="lax" binaryNumberRep="binary" bitOrder="mostSignificantBitFirst" byteOrder="bigEndian" choiceLengthKind="implicit" encoding="utf-8" encodingErrorPolicy="replace" escapeSchemeRef="" fillByte="%#r20;" floating="no" ignoreCase="no" initiatedContent="no" initiator="" leadingSkip="0" lengthKind="implicit" lengthUnits="bits" occursCountKind="implicit" prefixIncludesPrefixLength="no" representation="binary" separator="" separatorPosition="infix" sequenceKind="ordered" terminator="" textBidi="no" textPadKind="none" trailingSkip="0" truncateSpecifiedLengthString="no"/>
+      </dfdl:defineFormat>
+      <dfdl:format ref="idl:defaults"/>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:simpleType name="float" dfdl:length="32" dfdl:lengthKind="explicit" dfdl:alignment="32">
+    <xs:restriction base="xs:float"/>
+  </xs:simpleType>
+  <xs:simpleType name="double" dfdl:length="64" dfdl:lengthKind="explicit" dfdl:alignment="64">
+    <xs:restriction base="xs:double"/>
+  </xs:simpleType>
+  <xs:simpleType name="int8" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
+    <xs:restriction base="xs:byte"/>
+  </xs:simpleType>
+  <xs:simpleType name="int16" dfdl:length="16" dfdl:lengthKind="explicit" dfdl:alignment="16">
+    <xs:restriction base="xs:short"/>
+  </xs:simpleType>
+  <xs:simpleType name="int32" dfdl:length="32" dfdl:lengthKind="explicit" dfdl:alignment="32">
+    <xs:restriction base="xs:int"/>
+  </xs:simpleType>
+  <xs:simpleType name="int64" dfdl:length="64" dfdl:lengthKind="explicit" dfdl:alignment="64">
+    <xs:restriction base="xs:long"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint8" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
+    <xs:restriction base="xs:unsignedByte"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint16" dfdl:length="16" dfdl:lengthKind="explicit" dfdl:alignment="16">
+    <xs:restriction base="xs:unsignedShort"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint32" dfdl:length="32" dfdl:lengthKind="explicit" dfdl:alignment="32">
+    <xs:restriction base="xs:unsignedInt"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint64" dfdl:length="64" dfdl:lengthKind="explicit" dfdl:alignment="64">
+    <xs:restriction base="xs:unsignedLong"/>
+  </xs:simpleType>
+  <xs:simpleType name="boolean" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
+    <xs:restriction base="xs:boolean"/>
+  </xs:simpleType>
+  <xs:complexType name="FooType">
+    <xs:sequence>
+      <xs:element name="a" type="idl:int32"/>
+      <xs:element name="b" type="idl:int32"/>
+      <xs:element name="c" type="idl:int32"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="Foo" type="idl:FooType"/>
+  <xs:complexType name="BarType">
+    <xs:sequence>
+      <xs:element name="x" type="idl:double"/>
+      <xs:element name="y" type="idl:double"/>
+      <xs:element name="z" type="idl:double"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="Bar" type="idl:BarType"/>
+  <xs:complexType name="OuterStructType">
+    <xs:sequence>
+      <xs:element name="foo" type="idl:FooType"/>
+      <xs:element name="bar" type="idl:BarType"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="OuterStruct" type="idl:OuterStructType"/>
+  <xs:simpleType name="DayOfWeekType">
+    <xs:restriction base="idl:uint32"/>
+  </xs:simpleType>
+  <xs:complexType name="OuterUnionType">
+    <xs:sequence>
+      <xs:element name="tag" type="idl:DayOfWeekType"/>
+      <xs:element name="data" dfdl:length="192" dfdl:lengthKind="explicit" dfdl:alignment="64">
+        <xs:complexType>
+          <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
+            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:FooType"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:BarType"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="OuterUnion" type="idl:OuterUnionType"/>
+</xs:schema>

--- a/antlr/test/output/dfdl/nested.dfdl.xsd
+++ b/antlr/test/output/dfdl/nested.dfdl.xsd
@@ -57,44 +57,44 @@
   <xs:simpleType name="boolean" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
     <xs:restriction base="xs:boolean"/>
   </xs:simpleType>
-  <xs:complexType name="FooType">
+  <xs:complexType name="Foo">
     <xs:sequence>
       <xs:element name="a" type="idl:int32"/>
       <xs:element name="b" type="idl:int32"/>
       <xs:element name="c" type="idl:int32"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="Foo" type="idl:FooType"/>
-  <xs:complexType name="BarType">
+  <xs:element name="FooDecl" type="idl:Foo"/>
+  <xs:complexType name="Bar">
     <xs:sequence>
       <xs:element name="x" type="idl:double"/>
       <xs:element name="y" type="idl:double"/>
       <xs:element name="z" type="idl:double"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="Bar" type="idl:BarType"/>
-  <xs:complexType name="OuterStructType">
+  <xs:element name="BarDecl" type="idl:Bar"/>
+  <xs:complexType name="OuterStruct">
     <xs:sequence>
-      <xs:element name="foo" type="idl:FooType"/>
-      <xs:element name="bar" type="idl:BarType"/>
+      <xs:element name="foo" type="idl:Foo"/>
+      <xs:element name="bar" type="idl:Bar"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="OuterStruct" type="idl:OuterStructType"/>
-  <xs:simpleType name="DayOfWeekType">
+  <xs:element name="OuterStructDecl" type="idl:OuterStruct"/>
+  <xs:simpleType name="DayOfWeek">
     <xs:restriction base="idl:uint32"/>
   </xs:simpleType>
-  <xs:complexType name="OuterUnionType">
+  <xs:complexType name="OuterUnion">
     <xs:sequence>
-      <xs:element name="tag" type="idl:DayOfWeekType"/>
+      <xs:element name="tag" type="idl:DayOfWeek"/>
       <xs:element name="data" dfdl:length="192" dfdl:lengthKind="explicit" dfdl:alignment="64">
         <xs:complexType>
           <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
-            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:FooType"/>
-            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:BarType"/>
+            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:Foo"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:Bar"/>
           </xs:choice>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="OuterUnion" type="idl:OuterUnionType"/>
+  <xs:element name="OuterUnionDecl" type="idl:OuterUnion"/>
 </xs:schema>

--- a/antlr/test/output/dfdl/packed/nested.dfdl.xsd
+++ b/antlr/test/output/dfdl/packed/nested.dfdl.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:idl="urn:idl:1.0" targetNamespace="urn:idl:1.0">
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineFormat name="defaults">
+        <dfdl:format alignment="8" alignmentUnits="bits" binaryBooleanFalseRep="0" binaryBooleanTrueRep="1" binaryFloatRep="ieee" binaryNumberCheckPolicy="lax" binaryNumberRep="binary" bitOrder="mostSignificantBitFirst" byteOrder="bigEndian" choiceLengthKind="implicit" encoding="utf-8" encodingErrorPolicy="replace" escapeSchemeRef="" fillByte="%#r20;" floating="no" ignoreCase="no" initiatedContent="no" initiator="" leadingSkip="0" lengthKind="implicit" lengthUnits="bits" occursCountKind="implicit" prefixIncludesPrefixLength="no" representation="binary" separator="" separatorPosition="infix" sequenceKind="ordered" terminator="" textBidi="no" textPadKind="none" trailingSkip="0" truncateSpecifiedLengthString="no"/>
+      </dfdl:defineFormat>
+      <dfdl:format ref="idl:defaults"/>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:simpleType name="float" dfdl:length="32" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:float"/>
+  </xs:simpleType>
+  <xs:simpleType name="double" dfdl:length="64" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:double"/>
+  </xs:simpleType>
+  <xs:simpleType name="int8" dfdl:length="8" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:byte"/>
+  </xs:simpleType>
+  <xs:simpleType name="int16" dfdl:length="16" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:short"/>
+  </xs:simpleType>
+  <xs:simpleType name="int32" dfdl:length="32" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:int"/>
+  </xs:simpleType>
+  <xs:simpleType name="int64" dfdl:length="64" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:long"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint8" dfdl:length="8" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:unsignedByte"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint16" dfdl:length="16" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:unsignedShort"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint32" dfdl:length="32" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:unsignedInt"/>
+  </xs:simpleType>
+  <xs:simpleType name="uint64" dfdl:length="64" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:unsignedLong"/>
+  </xs:simpleType>
+  <xs:simpleType name="boolean" dfdl:length="8" dfdl:lengthKind="explicit">
+    <xs:restriction base="xs:boolean"/>
+  </xs:simpleType>
+  <xs:complexType name="FooType">
+    <xs:sequence>
+      <xs:element name="a" type="idl:int32"/>
+      <xs:element name="b" type="idl:int32"/>
+      <xs:element name="c" type="idl:int32"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="Foo" type="idl:FooType"/>
+  <xs:complexType name="BarType">
+    <xs:sequence>
+      <xs:element name="x" type="idl:double"/>
+      <xs:element name="y" type="idl:double"/>
+      <xs:element name="z" type="idl:double"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="Bar" type="idl:BarType"/>
+  <xs:complexType name="OuterStructType">
+    <xs:sequence>
+      <xs:element name="foo" type="idl:FooType"/>
+      <xs:element name="bar" type="idl:BarType"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="OuterStruct" type="idl:OuterStructType"/>
+  <xs:simpleType name="DayOfWeekType">
+    <xs:restriction base="idl:uint32"/>
+  </xs:simpleType>
+  <xs:complexType name="OuterUnionType">
+    <xs:sequence>
+      <xs:element name="tag" type="idl:DayOfWeekType"/>
+      <xs:element name="data" dfdl:length="192" dfdl:lengthKind="explicit">
+        <xs:complexType>
+          <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
+            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:FooType"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:BarType"/>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="OuterUnion" type="idl:OuterUnionType"/>
+</xs:schema>

--- a/antlr/test/output/dfdl/packed/nested.dfdl.xsd
+++ b/antlr/test/output/dfdl/packed/nested.dfdl.xsd
@@ -57,44 +57,44 @@
   <xs:simpleType name="boolean" dfdl:length="8" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:boolean"/>
   </xs:simpleType>
-  <xs:complexType name="FooType">
+  <xs:complexType name="Foo">
     <xs:sequence>
       <xs:element name="a" type="idl:int32"/>
       <xs:element name="b" type="idl:int32"/>
       <xs:element name="c" type="idl:int32"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="Foo" type="idl:FooType"/>
-  <xs:complexType name="BarType">
+  <xs:element name="FooDecl" type="idl:Foo"/>
+  <xs:complexType name="Bar">
     <xs:sequence>
       <xs:element name="x" type="idl:double"/>
       <xs:element name="y" type="idl:double"/>
       <xs:element name="z" type="idl:double"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="Bar" type="idl:BarType"/>
-  <xs:complexType name="OuterStructType">
+  <xs:element name="BarDecl" type="idl:Bar"/>
+  <xs:complexType name="OuterStruct">
     <xs:sequence>
-      <xs:element name="foo" type="idl:FooType"/>
-      <xs:element name="bar" type="idl:BarType"/>
+      <xs:element name="foo" type="idl:Foo"/>
+      <xs:element name="bar" type="idl:Bar"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="OuterStruct" type="idl:OuterStructType"/>
-  <xs:simpleType name="DayOfWeekType">
+  <xs:element name="OuterStructDecl" type="idl:OuterStruct"/>
+  <xs:simpleType name="DayOfWeek">
     <xs:restriction base="idl:uint32"/>
   </xs:simpleType>
-  <xs:complexType name="OuterUnionType">
+  <xs:complexType name="OuterUnion">
     <xs:sequence>
-      <xs:element name="tag" type="idl:DayOfWeekType"/>
+      <xs:element name="tag" type="idl:DayOfWeek"/>
       <xs:element name="data" dfdl:length="192" dfdl:lengthKind="explicit">
         <xs:complexType>
           <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
-            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:FooType"/>
-            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:BarType"/>
+            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:Foo"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:Bar"/>
           </xs:choice>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="OuterUnion" type="idl:OuterUnionType"/>
+  <xs:element name="OuterUnionDecl" type="idl:OuterUnion"/>
 </xs:schema>

--- a/demos/camera_demo/src/orion-command.dfdl.xsd
+++ b/demos/camera_demo/src/orion-command.dfdl.xsd
@@ -39,65 +39,62 @@
   <xs:simpleType name="uint32" dfdl:length="32" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:unsignedInt"/>
   </xs:simpleType>
-  <xs:element name="Command">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="sync0" fixed="208" type="idl:uint8"/>
-        <xs:element name="sync1" fixed="13" type="idl:uint8"/>
-        <xs:element name="id" fixed="1" type="idl:uint8"/>
-        <xs:element name="length" fixed="7" type="idl:uint8"/>
-        <xs:element name="pan" type="idl:int16"/>
-        <xs:element name="tilt">
-          <xs:simpleType>
-            <xs:restriction base="idl:int16">
-              <xs:minInclusive value="-1396"/>
-              <xs:maxInclusive value="733"/>
-            </xs:restriction>
-          </xs:simpleType>
-        </xs:element>
-        <xs:element name="mode" fixed="80" type="idl:uint8"/>
-        <xs:element name="stabilized" fixed="0" type="idl:uint8"/>
-        <xs:element name="impulse" fixed="0" type="idl:uint8"/>
-        <xs:element name="checksum" type="idl:uint16"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="CameraState">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="sync0" fixed="208" type="idl:uint8"/>
-        <xs:element name="sync1" fixed="13" type="idl:uint8"/>
-        <xs:element name="id" fixed="97" type="idl:uint8"/>
-        <xs:element name="length" fixed="5" type="idl:uint8"/>
-        <xs:element name="zoom" type="idl:int16"/>
-        <xs:element name="focus" type="idl:int16"/>
-        <xs:element name="index" fixed="0" type="idl:uint8"/>
-        <xs:element name="checksum" type="idl:uint16"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="VideoSettings">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="sync0" fixed="208" type="idl:uint8"/>
-        <xs:element name="sync1" fixed="13" type="idl:uint8"/>
-        <xs:element name="id" fixed="98" type="idl:uint8"/>
-        <xs:element name="length" fixed="14" type="idl:uint8"/>
-        <xs:element name="destIp">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:uint8"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-        <xs:element name="port" type="idl:uint16"/>
-        <xs:element name="bitrate" fixed="0" type="idl:uint32"/>
-        <xs:element name="ttl" fixed="0" type="idl:int8"/>
-        <xs:element name="streamType" fixed="0" type="idl:uint8"/>
-        <xs:element name="mjpegQuality" fixed="0" type="idl:uint8"/>
-        <xs:element name="saveSettingsAndTsPacketCount" fixed="0" type="idl:uint8"/>
-        <xs:element name="checksum" type="idl:uint16"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+  <xs:complexType name="Command">
+    <xs:sequence>
+      <xs:element name="sync0" fixed="208" type="idl:uint8"/>
+      <xs:element name="sync1" fixed="13" type="idl:uint8"/>
+      <xs:element name="id" fixed="1" type="idl:uint8"/>
+      <xs:element name="length" fixed="7" type="idl:uint8"/>
+      <xs:element name="pan" type="idl:int16"/>
+      <xs:element name="tilt">
+        <xs:simpleType>
+          <xs:restriction base="idl:int16">
+            <xs:minInclusive value="-1396"/>
+            <xs:maxInclusive value="733"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="mode" fixed="80" type="idl:uint8"/>
+      <xs:element name="stabilized" fixed="0" type="idl:uint8"/>
+      <xs:element name="impulse" fixed="0" type="idl:uint8"/>
+      <xs:element name="checksum" type="idl:uint16"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="CommandDecl" type="idl:Command"/>
+  <xs:complexType name="CameraState">
+    <xs:sequence>
+      <xs:element name="sync0" fixed="208" type="idl:uint8"/>
+      <xs:element name="sync1" fixed="13" type="idl:uint8"/>
+      <xs:element name="id" fixed="97" type="idl:uint8"/>
+      <xs:element name="length" fixed="5" type="idl:uint8"/>
+      <xs:element name="zoom" type="idl:int16"/>
+      <xs:element name="focus" type="idl:int16"/>
+      <xs:element name="index" fixed="0" type="idl:uint8"/>
+      <xs:element name="checksum" type="idl:uint16"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="CameraStateDecl" type="idl:CameraState"/>
+  <xs:complexType name="VideoSettings">
+    <xs:sequence>
+      <xs:element name="sync0" fixed="208" type="idl:uint8"/>
+      <xs:element name="sync1" fixed="13" type="idl:uint8"/>
+      <xs:element name="id" fixed="98" type="idl:uint8"/>
+      <xs:element name="length" fixed="14" type="idl:uint8"/>
+      <xs:element name="destIp">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:uint8"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="port" type="idl:uint16"/>
+      <xs:element name="bitrate" fixed="0" type="idl:uint32"/>
+      <xs:element name="ttl" fixed="0" type="idl:int8"/>
+      <xs:element name="streamType" fixed="0" type="idl:uint8"/>
+      <xs:element name="mjpegQuality" fixed="0" type="idl:uint8"/>
+      <xs:element name="saveSettingsAndTsPacketCount" fixed="0" type="idl:uint8"/>
+      <xs:element name="checksum" type="idl:uint16"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="VideoSettingsDecl" type="idl:VideoSettings"/>
 </xs:schema>


### PR DESCRIPTION
Fixed a bug in code generation for enums inside unions with C language target. The generated code included a namespace prefix and C enums do not have namespaces.

(I believe) fixed a bug in the code generation for enums inside unums with C++ language target. The generated code included the namespace prefix but not the enum typename prefix. Modified the code generation to include the namespace prefix and the enum typename prefix.

Added an enum as the tag type to nested.idl example to test more complex examples.

Fixed DFDL language target. Split the declaration of the xml simpleType/complexType and the xml element. Otherwise types cannot be reused.

Added test/output/dfdl with an example of generated code.