### PR TITLE
libpirate add pirate_print_stats() to API

### DIFF
--- a/demos/channel_demo/CMakeLists.txt
+++ b/demos/channel_demo/CMakeLists.txt
@@ -15,7 +15,7 @@ set(COMMON_SRC ${SRC_DIR}/common.c)
 
 function(add_channel_test_target TGT)
     add_executable(${TGT} ${COMMON_SRC} ${SRC_DIR}/${TGT}.c)
-    target_link_libraries(${TGT} ${PIRATE_APP_LIBS})
+    target_link_libraries(${TGT} ${PIRATE_APP_LIBS} pthread)
     target_compile_options(${TGT} PRIVATE ${BUILD_FLAGS})
 endfunction()
 

--- a/demos/channel_demo/src/common.c
+++ b/demos/channel_demo/src/common.c
@@ -188,6 +188,10 @@ int parse_common_options(int key, char *arg, channel_test_t *test,
         test->data.out_dir = arg;
         break;
 
+    case 'S':
+        test->stats.enable = 1;
+        break;
+
     case 'v':
         if (test->verbosity < VERBOSITY_MAX) {
             test->verbosity++;

--- a/demos/channel_demo/src/common.h
+++ b/demos/channel_demo/src/common.h
@@ -19,6 +19,8 @@
 #include <argp.h>
 #include <stdint.h>
 
+#include "libpirate.h"
+
 #define OPT_DELIM ","
 
 /* Verbosity levels */
@@ -66,6 +68,12 @@ typedef struct {
     } perf;
 } test_data_t;
 
+typedef struct {
+    int enable;
+    pthread_t threadId;
+    pirate_atomic_bool done;
+} stats_t;
+
 #define TEST_DATA_INIT(name_str) {           \
     .name         = name_str,                \
     .pattern      = DEFAULT_TEST_PATTERN,    \
@@ -86,6 +94,7 @@ typedef struct {
 /* Common test components */
 typedef struct {
     uint32_t verbosity;
+    stats_t stats;
     const char *conf;
     int gd;
     test_data_t data;
@@ -93,6 +102,7 @@ typedef struct {
 
 #define TEST_INIT(name_str) {             \
     .verbosity = VERBOSITY_NONE,          \
+    .stats     = {0, 0, 0},               \
     .conf      = NULL,                    \
     .gd        = -1,                      \
     .data      = TEST_DATA_INIT(name_str) \
@@ -105,6 +115,7 @@ typedef struct {
     { "length",  'l', "LEN",  0, "Test lengths <START,STOP,STEP>",    0 },  \
     { "input",   'i', "PATH", 0, "Binary input file path",            0 },  \
     { "save",    's', "DIR",  0, "Save test packets in a directory",  0 },  \
+    { "stats",   'S', NULL,   0, "Print periodic channel statistics", 0 },  \
     { "verbose", 'v', NULL,   0, "Increase verbosity level",          0 },  \
     { "perf",    'P', "PERF", 0, "Performance test: <MSG_LEN,COUNT>", 0 },  \
     { "delay",   'd', "NS",   0, "Inter-packet delay",                0 },  \

--- a/libpirate/CMakeLists.txt
+++ b/libpirate/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
     SET(PIRATE_SOURCES
         "primitives.c"
         "pirate_common.c"
+        "stats.c"
         "device.c"
         "pipe.c"
         "ge_eth.c"

--- a/libpirate/README.md
+++ b/libpirate/README.md
@@ -134,7 +134,7 @@ The writer may specify 0.0.0.0 for the address and 0 for the port.
 ### UDP_SOCKET type
 
 ```
-"udp_socket,reader addr,reader port[,buffer_size=N,mtu=N]"
+"udp_socket,reader addr,reader port,writer addr,writer port[,buffer_size=N,mtu=N]"
 ```
 
 UDP socket communication. Host and port of the reader process must be specified.

--- a/libpirate/include/libpirate.h
+++ b/libpirate/include/libpirate.h
@@ -24,6 +24,30 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+#if defined __has_include
+  #if __has_include (<stdatomic.h>)
+    #define HAVE_STD_ATOMIC 1
+  #endif
+#endif
+
+#ifdef HAVE_STD_ATOMIC
+  #ifdef __cplusplus
+    #include <atomic>
+    typedef std::atomic_bool pirate_atomic_bool;
+    #define PIRATE_ATOMIC_LOAD(PTR) std::atomic_load(PTR)
+    #define PIRATE_ATOMIC_STORE(PTR, VAL) std::atomic_store(PTR, VAL)
+  #else
+  #include <stdatomic.h>
+    typedef atomic_bool pirate_atomic_bool;
+    #define PIRATE_ATOMIC_LOAD(PTR) atomic_load(PTR)
+    #define PIRATE_ATOMIC_STORE(PTR, VAL) atomic_store(PTR, VAL)
+  #endif
+#else
+  typedef int pirate_atomic_bool;
+  #define PIRATE_ATOMIC_LOAD(PTR) __atomic_load(PTR, __ATOMIC_SEQ_CST)
+  #define PIRATE_ATOMIC_STORE(PTR, VAL) __atomic_store(PTR, VAL, __ATOMIC_SEQ_CST)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -287,23 +311,6 @@ typedef struct {
     int64_t fuzzed;
     int64_t bytes; // bytes is incremented only on successful requests
 } pirate_stats_t;
-
-#if defined __has_include
-#if __has_include (<stdatomic.h>)
-#define HAVE_STD_ATOMIC 1
-#endif
-#endif
-
-#ifdef HAVE_STD_ATOMIC
-#include <stdatomic.h>
-typedef atomic_bool pirate_atomic_bool;
-#define PIRATE_ATOMIC_LOAD(PTR) atomic_load(PTR)
-#define PIRATE_ATOMIC_STORE(PTR, VAL) atomic_store(PTR, VAL)
-#else
-typedef int pirate_atomic_bool;
-#define PIRATE_ATOMIC_LOAD(PTR) __atomic_load(PTR, __ATOMIC_SEQ_CST)
-#define PIRATE_ATOMIC_STORE(PTR, VAL) __atomic_store(PTR, VAL, __ATOMIC_SEQ_CST)
-#endif
 
 //
 // API

--- a/libpirate/include/libpirate.h
+++ b/libpirate/include/libpirate.h
@@ -474,7 +474,7 @@ const pirate_stats_t *pirate_get_stats(int gd);
 // requests: count of read or write requests
 // success: count of successful requests
 // errs: count of error requests. EAGAIN and EWOULDBLOCK are not errors
-// fuzzed: count of fuzzed requests.
+// fuzzed: count of fuzzed requests
 // bytes: sum of bytes over read or write requests
 
 void pirate_print_stats(FILE *stream, int pause_sec, pirate_atomic_bool* done, size_t ngds, int *gds);

--- a/libpirate/stats.c
+++ b/libpirate/stats.c
@@ -1,3 +1,18 @@
+/*
+ * This work was authored by Two Six Labs, LLC and is sponsored by a subcontract
+ * agreement with Galois, Inc.  This material is based upon work supported by
+ * the Defense Advanced Research Projects Agency (DARPA) under Contract No.
+ * HR0011-19-C-0103.
+ *
+ * The Government has unlimited rights to use, modify, reproduce, release,
+ * perform, display, or disclose computer software or computer software
+ * documentation marked with this legend. Any reproduction of technical data,
+ * computer software, or portions thereof marked with this legend must also
+ * reproduce this marking.
+ *
+ * Copyright 2021 Two Six Labs, LLC.  All rights reserved.
+ */
+
 #include "libpirate.h"
 
 #include <stdio.h>

--- a/libpirate/stats.c
+++ b/libpirate/stats.c
@@ -1,0 +1,82 @@
+#include "libpirate.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+
+#define TIMESTAMP_STR_LEN 64
+
+static inline int get_time(char ts[TIMESTAMP_STR_LEN], const char *fmt) {
+    struct timeval tv;
+    struct tm *now_tm;
+    int off;
+
+    if (gettimeofday(&tv, NULL) != 0) {
+        fprintf(stderr, "Failed to get the current time");
+        return -1;
+    }
+
+    if ((now_tm = localtime(&tv.tv_sec)) == NULL) {
+        fprintf(stderr, "Failed to convert time");
+        return -1;
+    }
+
+    off = strftime(ts, TIMESTAMP_STR_LEN, fmt, now_tm);
+    snprintf(ts + off, TIMESTAMP_STR_LEN - off, ".%06ld", tv.tv_usec);
+
+    return 0;
+}
+
+void pirate_print_stats(FILE *stream, int pause_sec, pirate_atomic_bool* done, size_t ngds, int *gds) {
+    pirate_stats_t *prev = (pirate_stats_t*) calloc(ngds, sizeof(pirate_stats_t));
+    pirate_stats_t *next = (pirate_stats_t*) calloc(ngds, sizeof(pirate_stats_t));
+    struct timespec ts;
+    char timestamp[TIMESTAMP_STR_LEN];
+
+    if (pause_sec < 1) {
+        fprintf(stream, "pause_sec must be greater than or equal to 1");
+        return;
+    }
+    if (ngds == 0) {
+        fprintf(stream, "ngds must be greater than 0");
+        return;
+    }
+    for (size_t i = 0; i < ngds; i++) {
+        memcpy(&prev[i], pirate_get_stats(gds[i]), sizeof(pirate_stats_t));
+    }
+    ts.tv_sec = pause_sec;
+    ts.tv_nsec = 0;
+    while ((done == NULL) || !PIRATE_ATOMIC_LOAD(done)) {
+        int rv = nanosleep(&ts, NULL);
+        if (rv < 0) {
+            perror("pirate_print_stats nanosleep error");
+            break;
+        }
+        if (get_time(timestamp, "%Y-%m-%d %H:%M:%S") != 0) {
+            fprintf(stream, "Failed to get the current time");
+            return;
+        }
+        for (size_t i = 0; i < ngds; i++) {
+            memcpy(&next[i], pirate_get_stats(gds[i]), sizeof(pirate_stats_t));
+        }
+        for (size_t i = 0; i < ngds; i++) {
+            pirate_stats_t *p = &prev[i];
+            pirate_stats_t *n = &next[i];  
+            p->requests = n->requests - p->requests;
+            p->success = n->success - p->success;
+            p->errs = n->errs - p->errs;
+            p->fuzzed = n->fuzzed - p->fuzzed;
+            p->bytes = n->bytes - p->bytes;
+            fprintf(stream, "[%s] LIBPIRATE %zu\trequests\t%f\n", timestamp, i, ((float) p->requests) / ((float) pause_sec));
+            fprintf(stream, "[%s] LIBPIRATE %zu\tsuccess\t\t%f\n", timestamp, i, ((float) p->success) / ((float) pause_sec));
+            fprintf(stream, "[%s] LIBPIRATE %zu\terrs\t\t%f\n", timestamp, i, ((float) p->errs) / ((float) pause_sec));
+            fprintf(stream, "[%s] LIBPIRATE %zu\tfuzzed\t\t%f\n", timestamp, i, ((float) p->fuzzed) / ((float) pause_sec));
+            fprintf(stream, "[%s] LIBPIRATE %zu\tbytes\t\t%f\n", timestamp, i, ((float) p->bytes) / ((float) pause_sec));
+        }
+        memcpy(prev, next, sizeof(pirate_stats_t) * ngds);
+    }
+    free(prev);
+    free(next);
+}

--- a/libpirate/stats.c
+++ b/libpirate/stats.c
@@ -84,11 +84,11 @@ void pirate_print_stats(FILE *stream, int pause_sec, pirate_atomic_bool* done, s
             p->errs = n->errs - p->errs;
             p->fuzzed = n->fuzzed - p->fuzzed;
             p->bytes = n->bytes - p->bytes;
-            fprintf(stream, "[%s] LIBPIRATE %zu\trequests\t%f\n", timestamp, i, ((float) p->requests) / ((float) pause_sec));
-            fprintf(stream, "[%s] LIBPIRATE %zu\tsuccess\t\t%f\n", timestamp, i, ((float) p->success) / ((float) pause_sec));
-            fprintf(stream, "[%s] LIBPIRATE %zu\terrs\t\t%f\n", timestamp, i, ((float) p->errs) / ((float) pause_sec));
-            fprintf(stream, "[%s] LIBPIRATE %zu\tfuzzed\t\t%f\n", timestamp, i, ((float) p->fuzzed) / ((float) pause_sec));
-            fprintf(stream, "[%s] LIBPIRATE %zu\tbytes\t\t%f\n", timestamp, i, ((float) p->bytes) / ((float) pause_sec));
+            fprintf(stream, "[%s] TRACE gaps descriptor %zu\trequests\t%f\n", timestamp, i, ((float) p->requests) / ((float) pause_sec));
+            fprintf(stream, "[%s] TRACE gaps descriptor %zu\tsuccess\t\t%f\n", timestamp, i, ((float) p->success) / ((float) pause_sec));
+            fprintf(stream, "[%s] TRACE gaps descriptor %zu\terrs\t\t%f\n", timestamp, i, ((float) p->errs) / ((float) pause_sec));
+            fprintf(stream, "[%s] TRACE gaps descriptor %zu\tfuzzed\t\t%f\n", timestamp, i, ((float) p->fuzzed) / ((float) pause_sec));
+            fprintf(stream, "[%s] TRACE gaps descriptor %zu\tbytes\t\t%f\n", timestamp, i, ((float) p->bytes) / ((float) pause_sec));
         }
         memcpy(prev, next, sizeof(pirate_stats_t) * ngds);
     }


### PR DESCRIPTION
`pirate_print_stats()` is a convenience function. If you look at the implementation of pirate_print_stats() it is just a wrapper around periodically invoking `pirate_get_stats()` and formatting the output.

Here is the documentation from libpirate.h:

```
// Periodically print statistics about gaps channels.
// This function loops indefinitely until the termination
// condition and should probably be invoked in its own thread.
//
// The set of gaps descriptors to be monitored is specified in the
// gds argument, which is an array of gaps descriptors. The length
// of gds is specified by ngds.
//
// Wait pause_sec seconds between intervals.
//
// If done is NULL then print statistics indefinitely.
// If done is non-NULL then PIRATE_ATOMIC_STORE(done, 1)
// will terminate the statistics printing.
//
// Prints the event rate (events per second) for the following metrics:
//
// requests: count of read or write requests
// success: count of successful requests
// errs: count of error requests. EAGAIN and EWOULDBLOCK are not errors
// fuzzed: count of fuzzed requests
// bytes: sum of bytes over read or write requests

void pirate_print_stats(FILE *stream, int pause_sec, pirate_atomic_bool* done, size_t ngds, int *gds);
```