### PR TITLE
camera demo: support MPEG-TS video stream reconnection

### DIFF
--- a/demos/camera_demo/src/main-gaps.cpp
+++ b/demos/camera_demo/src/main-gaps.cpp
@@ -169,7 +169,6 @@ void pirateCloseRemotes(const RemoteDescriptors &remotes) {
 int main(int argc, char *argv[])
 {
     int rv = 0, readerSuccess, writerSuccess;
-    bool tracing = false;
     Options options;
     RemoteDescriptors remotes;
     sigset_t set;
@@ -189,15 +188,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    if (ptrace(PTRACE_TRACEME, 0, 1, 0) < 0) {
-        tracing = true;
-    } else {
-        ptrace(PTRACE_DETACH, 0, 1, 0);
-    }
-
-    if (tracing) {
-        // allow SIGINT to continue working under gdb
-    } else {
+    if (!options.mGDB) {
         // block SIGINT for all threads except for the signalThread
         sigemptyset(&set);
         sigaddset(&set, SIGINT);
@@ -280,7 +271,7 @@ int main(int argc, char *argv[])
         goto cleanup;
     }
 
-    if (!tracing) {
+    if (!options.mGDB) {
         signalThread = new std::thread(waitInterrupt, nullptr);
     }
 

--- a/demos/camera_demo/src/main-monolith.cpp
+++ b/demos/camera_demo/src/main-monolith.cpp
@@ -58,22 +58,15 @@ static int waitInterrupt(void* arg) {
 int main(int argc, char *argv[])
 {
     int rv = 0;
-    bool tracing = false;
     Options options;
     sigset_t set;
     struct sigaction newaction;
     std::thread *signalThread = nullptr;
     std::vector<std::shared_ptr<FrameProcessor>> frameProcessors;
+ 
+    parseArgs(argc, argv, &options);
 
-    if (ptrace(PTRACE_TRACEME, 0, 1, 0) < 0) {
-        tracing = true;
-    } else {
-        ptrace(PTRACE_DETACH, 0, 1, 0);
-    }
-
-    if (tracing) {
-        // allow SIGINT to continue working under gdb
-    } else {
+    if (!options.mGDB) {
         // block SIGINT for all threads except for the signalThread
         sigemptyset(&set);
         sigaddset(&set, SIGINT);
@@ -83,8 +76,6 @@ int main(int argc, char *argv[])
         sigemptyset(&newaction.sa_mask);
         sigaction(SIGINT, &newaction, NULL);
     }
-
-    parseArgs(argc, argv, &options);
 
     CameraControlOutput *cameraControlOutput = nullptr;
     std::vector<std::shared_ptr<CameraControlInput>> cameraControlInputs;
@@ -163,7 +154,7 @@ int main(int argc, char *argv[])
         goto cleanup;
     }
 
-    if (!tracing) {
+    if (!options.mGDB) {
         signalThread = new std::thread(waitInterrupt, nullptr);
     }
 

--- a/demos/camera_demo/src/mpeg-ts-decoder.hpp
+++ b/demos/camera_demo/src/mpeg-ts-decoder.hpp
@@ -33,6 +33,12 @@ extern "C" {
 #include "options.hpp"
 #include "videosource.hpp"
 
+typedef enum {
+    INIT_SUCCESS = 0,
+    INIT_TIMEOUT  = 1,
+    INIT_FAILURE  = 2
+} init_video_result_t;
+
 class MpegTsDecoder : public VideoSource
 {
 public:
@@ -69,6 +75,8 @@ private:
     std::thread *mPollThread;
     bool mPoll;
 
+    init_video_result_t initVideo();
+    void termVideo();
     void pollThread();
     int processDataFrame();
     int processVideoFrame();

--- a/demos/camera_demo/src/options.hpp
+++ b/demos/camera_demo/src/options.hpp
@@ -64,6 +64,7 @@ struct Options
         mTiltAxisMax(45.0),
         mAngularPositionIncrement(1.0),
         mVerbose(false),
+        mGDB(false),
         mFFmpegLogLevel(8 /*AV_LOG_FATAL*/),
         mHasInput(false),
         mHasOutput(false),
@@ -106,6 +107,7 @@ struct Options
     float mTiltAxisMax;
     float mAngularPositionIncrement;
     bool mVerbose;
+    bool mGDB;
     int mFFmpegLogLevel;
     bool mHasInput;
     bool mHasOutput;

--- a/demos/camera_demo/src/optionsparser.cpp
+++ b/demos/camera_demo/src/optionsparser.cpp
@@ -38,7 +38,7 @@ const int OPT_FREESPACE     = 2500;
 const int OPT_GAPS_REQ      = 2600;
 const int OPT_GAPS_RSP      = 2700;
 const int OPT_COLOR_PICK    = 2800;
-
+const int OPT_GDB           = 2900;
 
 static struct argp_option options[] =
 {
@@ -75,6 +75,7 @@ static struct argp_option options[] =
     { "gaps_req",     OPT_GAPS_REQ,     "channel",  0, "gaps request channel",                      0 },
     { "gaps_rsp",     OPT_GAPS_RSP,     "channel",  0, "gaps response channel",                     0 },
     { "verbose",      'v',              NULL,       0, "verbose output",                            4 },
+    { "gdb",          OPT_GDB,          NULL,       0, "gdb support (disable SIGINT trap)",         0 },
     { "loglevel",     OPT_LOGLEVEL,     "val",      0, "ffmpeg libraries log level",                0 },
     { NULL,            0 ,              NULL,       0, NULL,                                        0 },
 };
@@ -328,6 +329,10 @@ static error_t parseOpt(int key, char * arg, struct argp_state * state)
 
         case 'v':
             opt->mVerbose = true;
+            break;
+
+        case OPT_GDB:
+            opt->mGDB = true;
             break;
 
         case OPT_GAPS_REQ:


### PR DESCRIPTION
The ffmpeg library does not support a separate timeout
variable for open() and read() operations on UDP video
streams. Therefore we teardown and reconnect the video
stream when read() encounters a timeout.

Successfully reproduced the error condition using the
Raspbery Pi camera. Verified that the patch fixes the
behavior. Ran the patch under valgrind to test for
memory leaks (see below).

This patch also reverts the use of ptrace() to determine
whether or not we are running under gdb. The behavior
doesn't work under valgrind and prevents us from using
valgrind. Reverted to a manual command-line option that
can be enabled when running under gdb.