### PR TITLE
vscode plug-in: add launch.json and tasks.json

### DIFF
--- a/vscode-plugins/architecture/.vscode/launch.json
+++ b/vscode-plugins/architecture/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "name": "Launch Extension",
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "npm compile",
+            "request": "launch",
+            "sourceMaps": true,
+            "type": "pwa-extensionHost"
+        }
+    ]
+}

--- a/vscode-plugins/architecture/.vscode/tasks.json
+++ b/vscode-plugins/architecture/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm compile",
+            "type": "npm",
+            "script": "compile",
+            "group": "build",
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "never"
+            },
+            "problemMatcher": [
+                "$tsc"
+            ]
+        },
+        {
+            "label": "npm watch",
+            "type": "npm",
+            "script": "watch",
+            "isBackground": true,
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "never"
+            },
+            "problemMatcher": [
+                "$tsc-watch"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I find it useful to have these, as you can start VSCode, and start the
background "watch" task to have the code continuously checked.

The launch task allows launching the extension for debugging, making sure it
has been compiled.