### PR TITLE
vscode plug-in: fix "npm run watch" script

### DIFF
--- a/vscode-plugins/architecture/package.json
+++ b/vscode-plugins/architecture/package.json
@@ -62,7 +62,7 @@
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -b ./tsconfig.json",
 		"lint": "eslint src --ext ts",
-		"watch": "./node_modules/.bin/nodemon --watch 'src/**/*.ts' --ignore 'src/**/*.spec.ts' --exec 'npm run compile'",
+		"watch": "nodemon --watch src --ext ts --exec 'npm run compile'",
 		"pretest": "npm run compile && npm run lint",
 		"test": "node ./out/test/runTest.js"
 	},


### PR DESCRIPTION
The existing command uses Unix glob patterns, which are explicitly listed as
not working in the nodemon documentation.  This fixes and simplifies the
script, looking at all .ts files in the src/ directory.