### PR TITLE
vscode plug-in: display buses

### DIFF
--- a/vscode-plugins/architecture/src/extension/parser.ts
+++ b/vscode-plugins/architecture/src/extension/parser.ts
@@ -512,10 +512,10 @@ const actorType: ObjectField[] = [
 /** Parser for bus */
 const busType: ObjectField[] = [
     reqObjField('orientation', enumField([A.BusOrientation.Horizontal, A.BusOrientation.Vertical])),
-    reqObjField('left',   numberField),
-    reqObjField('top',    numberField),
-    reqObjField('width',  numberField),
-    reqObjField('height', numberField),
+    reqObjField('left',   trackedNumberField),
+    reqObjField('top',    trackedNumberField),
+    reqObjField('width',  trackedNumberField),
+    reqObjField('height', trackedNumberField),
 ]
 
 /**

--- a/vscode-plugins/architecture/src/shared/architecture.ts
+++ b/vscode-plugins/architecture/src/shared/architecture.ts
@@ -67,10 +67,10 @@ export const enum BusOrientation {
  */
 export interface Bus extends NamedEntity {
     readonly orientation: BusOrientation
-    readonly left:   number
-    readonly top:    number
-    readonly height: number
-    readonly width:  number
+    readonly left: TrackedValue<number>
+    readonly top: TrackedValue<number>
+    readonly height: TrackedValue<number>
+    readonly width: TrackedValue<number>
 }
 
 export const enum EndpointType { Port = 'port', Bus = 'bus' }

--- a/vscode-plugins/architecture/src/webview/bus.ts
+++ b/vscode-plugins/architecture/src/webview/bus.ts
@@ -1,0 +1,46 @@
+import * as A from "../shared/architecture.js"
+import { DraggableRectangle } from "./draggableRectangle.js"
+import * as svg from './svg.js'
+import { SystemServices } from "./systemServices.js"
+
+export class BusView {
+    readonly draggableRectangle: DraggableRectangle
+
+    constructor(sys: SystemServices, parentSVG: SVGSVGElement, b: A.Bus) {
+
+        this.draggableRectangle = new DraggableRectangle(
+            sys,
+            parentSVG,
+            {
+                left: b.left,
+                top: b.top,
+                width: b.width,
+                height: b.height,
+            }
+        )
+
+        this.draggableRectangle.rect.style.fill = 'red'
+
+        var div = document.createElement('div')
+        var enclaveName = document.createElement('span') as HTMLSpanElement
+        enclaveName.classList.add('enclave-name')
+        enclaveName.innerHTML = b.name.value
+
+        div.appendChild(enclaveName)
+        div.onpointerdown = e => { e.stopImmediatePropagation() }
+
+        this.draggableRectangle.contentObject.append(div)
+    }
+
+    /** Remove all components from SVG */
+    dispose() {
+        this.draggableRectangle.dispose()
+    }
+
+    // get left(): number { return this.#svgContainer.x.baseVal.value }
+    // get top(): number { return this.#svgContainer.y.baseVal.value }
+    // get width(): number { return this.#svgContainer.width.baseVal.value }
+    // get height(): number { return this.#svgContainer.height.baseVal.value }
+    // get right(): number { return this.left + this.width }
+    // get bottom(): number { return this.top + this.height }
+}

--- a/vscode-plugins/architecture/src/webview/changeSet.ts
+++ b/vscode-plugins/architecture/src/webview/changeSet.ts
@@ -1,0 +1,16 @@
+import { common } from "../shared/webviewProtocol.js"
+
+export type TrackedIndex = number
+
+export class ChangeSet {
+    #edits: common.TrackUpdate[] = []
+
+    replace(locationId: number, newText: number | string): void {
+        this.#edits.push({
+            trackIndex: locationId,
+            newText: newText.toString(),
+        })
+    }
+
+    get edits() { return this.#edits }
+}

--- a/vscode-plugins/architecture/src/webview/draggableRectangle.ts
+++ b/vscode-plugins/architecture/src/webview/draggableRectangle.ts
@@ -1,0 +1,121 @@
+import { TrackedValue } from "../shared/architecture.js"
+import { SystemServices } from "./systemServices.js"
+import { ChangeSet, TrackedIndex } from "./changeSet.js"
+import * as D from "./dragHandlers.js"
+import { XYRange } from "./geometry.js"
+import * as svg from './svg.js'
+
+type TrackedIds = XYRange<TrackedIndex>
+
+type TrackedValues = XYRange<TrackedValue<number>>
+
+export class DraggableRectangle {
+
+    readonly contentObject: SVGForeignObjectElement
+    readonly rect: SVGRectElement
+    readonly #sys: SystemServices
+    readonly svgContainer: SVGSVGElement
+    readonly #trackedIds: TrackedIds
+
+    constructor(
+        sys: SystemServices,
+        parentSVG: SVGSVGElement,
+        trackedValues: TrackedValues,
+    ) {
+        this.#sys = sys
+        this.#trackedIds = {
+            left: trackedValues.left.trackId,
+            top: trackedValues.top.trackId,
+            width: trackedValues.width.trackId,
+            height: trackedValues.height.trackId,
+        }
+
+        // Offset for content
+        const offset = { x: 20, y: 20 }
+
+        // Create content
+        const svgContainer = document.createElementNS(svg.ns, 'svg') as SVGSVGElement
+        svg.setUserUnits(svgContainer.x, trackedValues.left.value)
+        svg.setUserUnits(svgContainer.y, trackedValues.top.value)
+        svg.setUserUnits(svgContainer.width, trackedValues.width.value)
+        svg.setUserUnits(svgContainer.height, trackedValues.height.value)
+        this.svgContainer = svgContainer
+        sys.whenIntTrackChanged(this.#trackedIds.left, (newValue) => {
+            svgContainer.x.baseVal.value = newValue
+        })
+        sys.whenIntTrackChanged(this.#trackedIds.top, (newValue) => {
+            svgContainer.y.baseVal.value = newValue
+        })
+        sys.whenIntTrackChanged(this.#trackedIds.width, (newValue) => {
+            svgContainer.width.baseVal.value = newValue
+        })
+        sys.whenIntTrackChanged(this.#trackedIds.height, (newValue) => {
+            svgContainer.height.baseVal.value = newValue
+        })
+
+        this.rect = document.createElementNS(svg.ns, 'rect') as SVGRectElement
+        this.rect.classList.add('enclave')
+        svg.setPercentageUnits(this.rect.x, 0)
+        svg.setPercentageUnits(this.rect.y, 0)
+        svg.setPercentageUnits(this.rect.width, 100)
+        svg.setPercentageUnits(this.rect.height, 100)
+
+        D.addSVGDragHandlers(parentSVG, svgContainer, (e) => this.drag(e))
+
+        this.contentObject = document.createElementNS(svg.ns, 'foreignObject') as SVGForeignObjectElement
+        this.contentObject.x.baseVal.value = offset.x
+        this.contentObject.y.baseVal.value = offset.y
+        svg.setPercentageUnits(this.contentObject.width, 100)
+        svg.setPercentageUnits(this.contentObject.height, 100)
+
+        svgContainer.appendChild(this.rect)
+        svgContainer.appendChild(this.contentObject)
+        parentSVG.appendChild(svgContainer)
+    }
+
+    drag(evt: D.SVGDragEvent) {
+        const svgContainer = this.svgContainer
+        const sys = this.#sys
+        let newLeft = evt.left
+        let newTop = evt.top
+        const width = svgContainer.width.baseVal.value
+        const height = svgContainer.height.baseVal.value
+
+        // Adjust to not overlap
+        newLeft = sys.adjustX(this, { top: newTop, height: height }, width, svgContainer.x.baseVal.value, newLeft)
+        newTop = sys.adjustY(this, { left: newLeft, width: width }, height, svgContainer.y.baseVal.value, newTop)
+
+        // Get new coordinates
+        let r = {
+            left: newLeft,
+            top: newTop,
+            right: newLeft + width,
+            bottom: newTop + height
+        }
+
+        if (!sys.overlaps(this, r)) {
+            let changes = new ChangeSet()
+            if (svgContainer.x.baseVal.value !== newLeft) {
+                svgContainer.x.baseVal.value = newLeft
+                changes.replace(this.#trackedIds.left, newLeft)
+            }
+            if (svgContainer.y.baseVal.value !== newTop) {
+                svgContainer.y.baseVal.value = newTop
+                changes.replace(this.#trackedIds.top, newTop)
+            }
+            sys.sendUpdateDoc(changes)
+        }
+    };
+
+    /** Remove all components from SVG */
+    dispose() {
+        this.svgContainer.remove()
+    }
+
+    get left(): number { return this.svgContainer.x.baseVal.value }
+    get top(): number { return this.svgContainer.y.baseVal.value }
+    get width(): number { return this.svgContainer.width.baseVal.value }
+    get height(): number { return this.svgContainer.height.baseVal.value }
+    get right(): number { return this.left + this.width }
+    get bottom(): number { return this.top + this.height }
+}

--- a/vscode-plugins/architecture/src/webview/geometry.ts
+++ b/vscode-plugins/architecture/src/webview/geometry.ts
@@ -1,0 +1,16 @@
+export interface Bottom<T> { readonly bottom: T }
+export interface Height<T> { readonly height: T }
+export interface Left<T> { readonly left: T }
+export interface Right<T> { readonly right: T }
+export interface Top<T> { readonly top: T }
+export interface Width<T> { readonly width: T }
+
+export type XRange<T> = Left<T> & Width<T>
+export type YRange<T> = Top<T> & Height<T>
+
+export type XYRange<T> = XRange<T> & YRange<T>
+
+export type LeftTopPosition<T> = Left<T> & Top<T>
+export type BottomRightPosition<T> = Bottom<T> & Right<T>
+
+export type Rectangle<T> = LeftTopPosition<T> & BottomRightPosition<T>

--- a/vscode-plugins/architecture/src/webview/systemServices.ts
+++ b/vscode-plugins/architecture/src/webview/systemServices.ts
@@ -1,0 +1,34 @@
+import * as A from "../shared/architecture.js"
+import { ChangeSet, TrackedIndex } from "./changeSet.js"
+import { Rectangle, XRange, YRange } from "./geometry.js"
+
+export interface SystemServices {
+    /**
+     * Return true if @r@ overlaps with any object other than `thisObject`.
+     */
+    overlaps(thisObject: any, r: Rectangle<number>): boolean
+    /**
+     * Adjust the left coordinate to avoid overlapping.
+     */
+    adjustX(thisObject: any, r: YRange<number>, width: number, oldLeft: number, newLeft: number): number;
+    /**
+     * Adjust the left coordinate to avoid overlapping.
+     */
+    adjustY(thisObject: any, r: XRange<number>, height: number, oldTop: number, newTop: number): number;
+    /**
+     * Request we open a text editor at the given location.
+     */
+    visitURI(idx: A.LocationIndex): void
+    /**
+     * Send an update doc request
+     */
+    sendUpdateDoc(changes: ChangeSet): void
+    /**
+     * Add listener to respond to when a tracked value changes.
+     */
+    whenStringTrackChanged(trackedIndex: TrackedIndex, listener: (newValue: string) => void): void
+    /**
+     * Add listener to respond to when a tracked value changes.
+     */
+    whenIntTrackChanged(trackedIndex: TrackedIndex, listener: (newValue: number) => void): void
+}


### PR DESCRIPTION
Beginning support for displaying buses.

Currently they display as red-filled rectangles, and support dragging around.

Due to the number of objects with collision, we will likely want to allow "jumping" over objects while dragging, but this can be a separate PR.