### PR TITLE
vscode-plugin: add .gitattributes for package-lock.json

### DIFF
--- a/vscode-plugins/architecture/.gitattributes
+++ b/vscode-plugins/architecture/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json -diff


### PR DESCRIPTION
When this file changes, it makes large, uninteresting diffs.  This tells git
not to display those diffs.