### PR TITLE
Architecture plugin: Add ready message from webview

### DIFF
--- a/vscode-plugins/architecture/README.md
+++ b/vscode-plugins/architecture/README.md
@@ -1,5 +1,22 @@
-# Pirate Architecture Modeling Plugin README
+# PIRATE architecture plugin
 
 The Pirate architecture modeling plugin aims to provide VSCode users
-with visualization and editing tools for PIRATE project files.  These
-files are intended to capture all the flows that go
+with visualization and editing tools for PIRATE architecture files.
+These are intended to illustrate the system architectures and provide
+an alternative means for navigating the code in an application.
+
+## Building
+
+The first step to building this extension is to install [npm](https://www.npmjs.com/)
+and VSCode.  Once npm is installed, you can install the dependencies by running:
+
+```
+npm install
+```
+
+Once the dependencies are installed, you can debug the extension with VSCode by
+start debugging (F5) or build it manually by running:
+
+```
+npm run compile
+```

--- a/vscode-plugins/architecture/src/extension/modelResources.ts
+++ b/vscode-plugins/architecture/src/extension/modelResources.ts
@@ -177,7 +177,7 @@ export class ModelResources implements ModelWebviewServices {
      */
     public resolvePirateGraphViewer(context: vscode.ExtensionContext, webviewPanel: vscode.WebviewPanel): void {
         // Create webview
-        const view:ModelWebview = new ModelWebview(context, this, webviewPanel)
+        const view:ModelWebview = new ModelWebview(context, this, webviewPanel, this.system)
         // Append new system model webview to active webviews.
         this.#activeWebviews.add(view)
         // Make sure we get rid of the listener when our editor is closed.
@@ -186,7 +186,5 @@ export class ModelResources implements ModelWebviewServices {
             this.#activeWebviews.delete(view)
             view.dispose()
         })
-        const mdl = this.system
-        if (mdl) view.setModel(mdl)
     }
 }

--- a/vscode-plugins/architecture/src/shared/webviewProtocol.ts
+++ b/vscode-plugins/architecture/src/shared/webviewProtocol.ts
@@ -56,16 +56,22 @@ export namespace extension {
 // Namespace for messages and types passed from webview to extension
 export namespace webview {
     export const enum Tag {
+        Ready, // Indicates webview is now listening.
         VisitURI,
         UpdateDocument,
         SetSystemModelDone
     }
 
     /** Type for events from view to extension. */
-    export type Event = VisitURI | UpdateDocument | SetSystemModelDone
+    export type Event = Ready | VisitURI | UpdateDocument | SetSystemModelDone
+
+    /** Indicates webview is now ready for other events. */
+    export interface Ready {
+        readonly tag: Tag.Ready
+    }
 
     /**
-     *  Class for commands to visit a URI in the editor.
+     *  Command to visit a URI in the editor.
      */
     export interface VisitURI {
         readonly tag: Tag.VisitURI

--- a/vscode-plugins/architecture/src/webview/webview.ts
+++ b/vscode-plugins/architecture/src/webview/webview.ts
@@ -230,5 +230,6 @@ const vscode = acquireVsCodeApi()
                     break
             }
         })
+        vscode.postMessage({tag:  webview.Tag.Ready})
     }
 }


### PR DESCRIPTION
This addresses a problem that occurs when the extension posts a model before the webview had registered a message event handler.

I also happened to update the readme.