### PR TITLE
vscode plug-in: display connections and update listeners

### DIFF
--- a/vscode-plugins/architecture/src/extension/modelResources.ts
+++ b/vscode-plugins/architecture/src/extension/modelResources.ts
@@ -157,7 +157,7 @@ export class ModelResources implements ModelWebviewServices {
         const doEdit = () => {
             this.#expectedEdits = edit
             for (const v of this.#activeWebviews) {
-                if (v !== source) { v.notifyDocumentEdited(edit.array) }
+                v.notifyDocumentEdited(edit.array)
             }
             const wsEdit = doc.mkWorkspaceEdit(edit)
             vscode.workspace.applyEdit(wsEdit).then((success) => {

--- a/vscode-plugins/architecture/src/webview/changeSet.ts
+++ b/vscode-plugins/architecture/src/webview/changeSet.ts
@@ -12,5 +12,5 @@ export class ChangeSet {
         })
     }
 
-    get edits(): common.TrackUpdate[] { return this.#edits }
+    get edits(): readonly common.TrackUpdate[] { return this.#edits }
 }

--- a/vscode-plugins/architecture/src/webview/draggableRectangle.ts
+++ b/vscode-plugins/architecture/src/webview/draggableRectangle.ts
@@ -16,7 +16,7 @@ export class DraggableRectangle {
     readonly rect: SVGRectElement
     readonly #sys: SystemServices
     readonly svgContainer: SVGSVGElement
-    readonly #trackedIds: TrackedIds
+    readonly trackedIds: TrackedIds
 
     constructor(
         sys: SystemServices,
@@ -24,7 +24,7 @@ export class DraggableRectangle {
         trackedValues: TrackedValues,
     ) {
         this.#sys = sys
-        this.#trackedIds = {
+        this.trackedIds = {
             left: trackedValues.left.trackId,
             top: trackedValues.top.trackId,
             width: trackedValues.width.trackId,
@@ -41,16 +41,16 @@ export class DraggableRectangle {
         svg.setUserUnits(svgContainer.width, trackedValues.width.value)
         svg.setUserUnits(svgContainer.height, trackedValues.height.value)
         this.svgContainer = svgContainer
-        sys.whenIntTrackChanged(this.#trackedIds.left, (newValue) => {
+        sys.whenIntTrackChanged(this.trackedIds.left, (newValue) => {
             svgContainer.x.baseVal.value = newValue
         })
-        sys.whenIntTrackChanged(this.#trackedIds.top, (newValue) => {
+        sys.whenIntTrackChanged(this.trackedIds.top, (newValue) => {
             svgContainer.y.baseVal.value = newValue
         })
-        sys.whenIntTrackChanged(this.#trackedIds.width, (newValue) => {
+        sys.whenIntTrackChanged(this.trackedIds.width, (newValue) => {
             svgContainer.width.baseVal.value = newValue
         })
-        sys.whenIntTrackChanged(this.#trackedIds.height, (newValue) => {
+        sys.whenIntTrackChanged(this.trackedIds.height, (newValue) => {
             svgContainer.height.baseVal.value = newValue
         })
 
@@ -75,34 +75,29 @@ export class DraggableRectangle {
     }
 
     drag(evt: D.SVGDragEvent): void {
-        const svgContainer = this.svgContainer
         const sys = this.#sys
         let newLeft = evt.left
         let newTop = evt.top
-        const width = svgContainer.width.baseVal.value
-        const height = svgContainer.height.baseVal.value
 
         // Adjust to not overlap
-        newLeft = sys.adjustX(this, { top: newTop, height: height }, width, svgContainer.x.baseVal.value, newLeft)
-        newTop = sys.adjustY(this, { left: newLeft, width: width }, height, svgContainer.y.baseVal.value, newTop)
+        newLeft = sys.adjustX(this, { top: newTop, height: this.height }, this.width, this.left, newLeft)
+        newTop = sys.adjustY(this, { left: newLeft, width: this.width }, this.height, this.top, newTop)
 
         // Get new coordinates
         const r = {
             left: newLeft,
             top: newTop,
-            right: newLeft + width,
-            bottom: newTop + height,
+            right: newLeft + this.width,
+            bottom: newTop + this.height,
         }
 
         if (!sys.overlaps(this, r)) {
             const changes = new ChangeSet()
-            if (svgContainer.x.baseVal.value !== newLeft) {
-                svgContainer.x.baseVal.value = newLeft
-                changes.replace(this.#trackedIds.left, newLeft)
+            if (this.left !== newLeft) {
+                changes.replace(this.trackedIds.left, newLeft)
             }
-            if (svgContainer.y.baseVal.value !== newTop) {
-                svgContainer.y.baseVal.value = newTop
-                changes.replace(this.#trackedIds.top, newTop)
+            if (this.top !== newTop) {
+                changes.replace(this.trackedIds.top, newTop)
             }
             sys.sendUpdateDoc(changes)
         }

--- a/vscode-plugins/architecture/src/webview/systemServices.ts
+++ b/vscode-plugins/architecture/src/webview/systemServices.ts
@@ -4,32 +4,47 @@ import { ChangeSet, TrackedIndex } from './changeSet.js'
 import { Rectangle, XRange, YRange } from './geometry.js'
 
 export interface SystemServices {
+
     /**
      * Return true if @r@ overlaps with any object other than `thisObject`.
      */
     overlaps(_thisObject: unknown, _r: Rectangle<number>): boolean
+
     /**
      * Adjust the left coordinate to avoid overlapping.
      */
     adjustX(_thisObject: unknown, _r: YRange<number>, _width: number, _oldLeft: number, _newLeft: number): number;
+
     /**
      * Adjust the left coordinate to avoid overlapping.
      */
     adjustY(_thisObject: unknown, _r: XRange<number>, _height: number, _oldTop: number, _newTop: number): number;
+
     /**
      * Request we open a text editor at the given location.
      */
     visitURI(_idx: A.LocationIndex): void
+
     /**
      * Send an update doc request
      */
     sendUpdateDoc(_changes: ChangeSet): void
-    /**
-     * Add listener to respond to when a tracked value changes.
-     */
-    whenStringTrackChanged(_trackedIndex: TrackedIndex, _listener: (_newValue: string) => void): void
+
     /**
      * Add listener to respond to when a tracked value changes.
      */
     whenIntTrackChanged(_trackedIndex: TrackedIndex, _listener: (_newValue: number) => void): void
+
+    /**
+     * Add listener to respond to when a tracked value changes.
+     */
+    whenStringTrackChanged(_trackedIndex: TrackedIndex, _listener: (_newValue: string) => void): void
+
+    whenTrackedChanged<V>(
+        _idx: TrackedIndex,
+        _parser: (_newValue: string) => V | undefined,
+        _listener: (_newValue: V) => void,
+    ): void
+
+
 }

--- a/vscode-plugins/architecture/src/webview/tsconfig.json
+++ b/vscode-plugins/architecture/src/webview/tsconfig.json
@@ -14,6 +14,8 @@
         "systemServices.ts",
         "views/actor.ts",
         "views/bus.ts",
+        "views/connection.ts",
+        "views/port.ts",
         "webview.ts"
     ],
     "references": [

--- a/vscode-plugins/architecture/src/webview/views/actor.ts
+++ b/vscode-plugins/architecture/src/webview/views/actor.ts
@@ -1,188 +1,25 @@
 import * as A from '../../shared/architecture.js'
-import { ChangeSet } from '../changeSet.js'
-import * as D from '../dragHandlers.js'
 import { DraggableRectangle } from '../draggableRectangle.js'
-import * as svg from '../svg.js'
 import { SystemServices } from '../systemServices.js'
 
-/** `outsideRangeDist(x,l,h)` returns the amount `x` is outside the range `[l,h]`. */
-function outsideRangeDist(x: number, l: number, h: number): number {
-    if (x < l) {
-        return l - x
-    } else if (x > h) {
-        return h - x
-    } else {
-        return 0
-    }
-}
-
-/**
- * `euclid2Dist(x, y)` returns `sqrt(x * x + y * y)`.
- *
- * It has special cases and assumes `x` and `y` are non-negative.
- */
-function euclid2Dist(x: number, y: number) {
-    if (x === 0) {
-        return y
-    } else if (y === 0) {
-        return x
-    } else {
-        return Math.sqrt(x * x + y * y)
-    }
-}
-
-enum PortDir { Out = 'Out', In = 'In' }
-
-/**
- * Clamp a number between a minimum and maximum value.
- */
-function clamp(v: number, min: number, max: number) {
-    return Math.min(Math.max(v, min), max)
-}
-
-/**
- * This calculate the orientation of the
- */
-function calculatePortRotate(dir: PortDir, left: number, maxLeft: number, top: number, maxTop: number) {
-    let orient: number
-    if (top <= 0) {
-        orient = 0
-    } else if (top < maxTop) {
-        orient = (left <= 0) ? 270 : 90
-    } else {
-        orient = 180
-    }
-
-    const inPort = dir === PortDir.In
-
-    return (orient + (inPort ? 90 : 270)) % 360
-}
-
-/**
- * Generate rotate string for a SVG CSS transform attribute.
- */
-function rotateString(rotate: number, xoff: number, yoff: number): string {
-    return `rotate(${rotate.toString()}, ${xoff.toString()}, ${yoff.toString()})`
-
-}
-/**
- * Set the position and orientationof a port use element.
- *
- * @param svg Outer SVG element
- * @param elt Use element
- * @param bbox Bounding box of a element
- * @param portDir Type of port
- * @param border Border that port sits on
- * @param position Position along border that port is on.
- */
-function setPortElementPosition(svg: SVGSVGElement, elt: SVGUseElement, bbox: DOMRect, portDir: PortDir, border: A.Border, position: number): number {
-    // Maximum left value
-    const maxLeft = svg.width.baseVal.value - bbox.width
-    // Maximum top value
-    const maxTop = svg.height.baseVal.value - bbox.height
-    let offset: number
-    switch (border) {
-        case A.Border.Left:
-            offset = clamp(position, 0, maxTop)
-            elt.x.baseVal.value = 0
-            elt.y.baseVal.value = offset
-            break
-        case A.Border.Right:
-            offset = clamp(position, 0, maxTop)
-            elt.x.baseVal.value = maxLeft
-            elt.y.baseVal.value = offset
-            break
-        case A.Border.Top:
-            offset = clamp(position, 0, maxLeft)
-            elt.x.baseVal.value = offset
-            elt.y.baseVal.value = 0
-            break
-        case A.Border.Bottom:
-            offset = clamp(position, 0, maxLeft)
-            elt.x.baseVal.value = offset
-            elt.y.baseVal.value = maxTop
-            break
-    }
-    // Populate initial transform attribute.
-    const rotate = calculatePortRotate(portDir, elt.x.baseVal.value, maxLeft, elt.y.baseVal.value, maxTop)
-    const centerX = elt.x.baseVal.value + bbox.width / 2
-    const centerY = elt.y.baseVal.value + bbox.height / 2
-    elt.setAttributeNS('', 'transform', rotateString(rotate, centerX, centerY))
-    return offset
-}
-
-/**
- * Represents a port on a service.
- */
-class PortView {
-    // Element we created for port
-    readonly elt: SVGUseElement
-
-    /**
-     * Create a new port.
-     */
-    constructor(sys: SystemServices, actorSVG: SVGSVGElement, dir: PortDir, p: A.Port) {
-        const portType = dir
-        const elt = document.createElementNS(svg.ns, 'use') as SVGUseElement
-        elt.setAttributeNS('', 'href', '#inPort')
-        actorSVG.appendChild(elt)
-        this.elt = elt
-
-        const bbox = elt.getBBox()
-
-        const curBorder = p.border.value
-        let curOffset = p.offset.value
-
-        setPortElementPosition(actorSVG, elt, bbox, portType, curBorder, p.offset.value)
-
-        D.addSVGDragHandlers(actorSVG, elt, (evt: D.SVGDragEvent) => {
-            // Maximum left value
-            const maxLeft = actorSVG.width.baseVal.value - bbox.width
-            // Maximum top value
-            const maxTop = actorSVG.height.baseVal.value - bbox.height
-            // Calculate x distance above or below max.
-            const xDist = outsideRangeDist(evt.left, 0, maxLeft)
-            // Calculate y distance above or below max.
-            const yDist = outsideRangeDist(evt.top, 0, maxTop)
-
-            const distLeft = euclid2Dist(Math.abs(evt.left), yDist)
-            const distRight = euclid2Dist(Math.abs(maxLeft - evt.left), yDist)
-            const distTop = euclid2Dist(Math.abs(evt.top), xDist)
-            const distBottom = euclid2Dist(Math.abs(maxTop - evt.top), xDist)
-            const distMin = Math.min(distLeft, distTop, distRight, distBottom)
-
-            let border: A.Border
-            let offset: number
-            if (distLeft === distMin) {
-                border = A.Border.Left
-                offset = evt.top
-            } else if (distRight === distMin) {
-                border = A.Border.Right
-                offset = evt.top
-            } else if (distTop === distMin) {
-                border = A.Border.Top
-                offset = evt.left
-            } else {
-                border = A.Border.Bottom
-                offset = evt.left
-            }
-            offset = setPortElementPosition(actorSVG, elt, bbox, portType, border, offset)
-            const changes = new ChangeSet()
-            if (curBorder !== border) { changes.replace(p.border.trackId, border) }
-            if (curOffset !== offset) {
-                curOffset = offset
-                changes.replace(p.offset.trackId, offset)
-            }
-            sys.sendUpdateDoc(changes)
-        })
-    }
-
-}
+import { PortDir, PortView } from './port.js'
 
 export class ActorView {
     readonly draggableRectangle: DraggableRectangle
+    readonly name: string
+    readonly inPorts: PortView[]
+    readonly outPorts: PortView[]
+
+    get allPorts(): readonly PortView[] {
+        return ([] as PortView[]).concat(
+            this.inPorts,
+            this.outPorts,
+        )
+    }
 
     constructor(sys: SystemServices, parentSVG: SVGSVGElement, a: A.Actor) {
+
+        this.name = a.name.value
 
         this.draggableRectangle = new DraggableRectangle(
             sys,
@@ -214,8 +51,12 @@ export class ActorView {
 
         this.draggableRectangle.contentObject.appendChild(div)
 
-        for (const p of a.inPorts) { new PortView(sys, this.draggableRectangle.svgContainer, PortDir.In, p) }
-        for (const p of a.outPorts) { new PortView(sys, this.draggableRectangle.svgContainer, PortDir.Out, p) }
+        this.inPorts = a.inPorts.map(p =>
+            new PortView(sys, this, PortDir.In, p)
+        )
+        this.outPorts = a.outPorts.map(p =>
+            new PortView(sys, this, PortDir.Out, p)
+        )
     }
 
     /** Remove all components from SVG */

--- a/vscode-plugins/architecture/src/webview/views/bus.ts
+++ b/vscode-plugins/architecture/src/webview/views/bus.ts
@@ -4,8 +4,13 @@ import { SystemServices } from '../systemServices.js'
 
 export class BusView {
     readonly draggableRectangle: DraggableRectangle
+    readonly name: string
+    readonly orientation: A.BusOrientation
 
     constructor(sys: SystemServices, parentSVG: SVGSVGElement, b: A.Bus) {
+
+        this.name = b.name.value
+        this.orientation = b.orientation
 
         this.draggableRectangle = new DraggableRectangle(
             sys,

--- a/vscode-plugins/architecture/src/webview/views/connection.ts
+++ b/vscode-plugins/architecture/src/webview/views/connection.ts
@@ -1,0 +1,165 @@
+import * as A from '../../shared/architecture.js'
+import * as svg from '../svg.js'
+import { SystemServices } from '../systemServices.js'
+
+import { BusView } from './bus.js'
+import { PortView } from './port.js'
+
+export type Connectable = BusView | PortView
+
+export class ConnectionView {
+
+    readonly line: SVGLineElement
+
+    updateSourcePosition(): void {
+
+        if (this.source instanceof BusView) {
+            this.x1 = this.x2
+            this.y1 = this.source.draggableRectangle.top
+        }
+
+        if (this.source instanceof PortView) {
+            this.x1 = this.source.actor.draggableRectangle.left + this.source.centerX
+            this.y1 = this.source.actor.draggableRectangle.top + this.source.centerY
+            if (this.target instanceof BusView) {
+                if (this.target.orientation === A.BusOrientation.Horizontal) {
+                    this.x2 = this.x1
+                }
+                if (this.target.orientation === A.BusOrientation.Vertical) {
+                    this.y2 = this.y1
+                }
+            }
+        }
+
+    }
+
+    updateTargetPosition(): void {
+
+        if (this.target instanceof BusView) {
+            this.x2 = this.x1
+            this.y2 = this.target.draggableRectangle.top
+        }
+
+        if (this.target instanceof PortView) {
+            this.x2 = this.target.actor.draggableRectangle.left + this.target.centerX
+            this.y2 = this.target.actor.draggableRectangle.top + this.target.centerY
+            if (this.source instanceof BusView) {
+                if (this.source.orientation === A.BusOrientation.Horizontal) {
+                    this.x1 = this.x2
+                }
+                if (this.source.orientation === A.BusOrientation.Vertical) {
+                    this.y1 = this.y2
+                }
+            }
+        }
+
+    }
+
+    getPortViewX(connectable: Connectable): number {
+        if (connectable instanceof PortView) {
+            return connectable.actor.draggableRectangle.left + connectable.centerX
+        }
+        if (connectable instanceof BusView) {
+            console.log("Error: don't know how to display a connection between two BusViews")
+        }
+        console.log('Error: unexpected Connectable in getPortViewX')
+        return 0
+    }
+
+    constructor(
+        sys: SystemServices,
+        parentSVG: SVGSVGElement,
+        readonly source: Connectable,
+        readonly target: Connectable,
+    ) {
+        this.line = document.createElementNS(svg.ns, 'line') as SVGLineElement
+        this.line.classList.add('connection')
+        this.line.setAttribute('stroke', 'green')
+        this.line.setAttribute('stroke-width', '5')
+
+        if (source instanceof PortView) {
+            // initial values
+            this.x1 = source.actor.draggableRectangle.left + source.centerX
+            this.y1 = source.actor.draggableRectangle.top + source.centerY
+            // updates
+            sys.whenIntTrackChanged(source.offsetId, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.left, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.top, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.width, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.height, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.left, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.top, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.width, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(source.actor.draggableRectangle.trackedIds.height, () => this.updateTargetPosition())
+        }
+
+        if (source instanceof BusView) {
+            if (source.orientation === A.BusOrientation.Horizontal) {
+                this.x1 = this.getPortViewX(target)
+                this.y1 = source.draggableRectangle.top
+                sys.whenIntTrackChanged(
+                    source.draggableRectangle.trackedIds.top,
+                    () => this.updateSourcePosition(),
+                )
+            }
+            if (source.orientation === A.BusOrientation.Vertical) {
+                this.x1 = source.draggableRectangle.left
+                this.y1 = this.y2
+                sys.whenIntTrackChanged(
+                    source.draggableRectangle.trackedIds.left,
+                    () => this.updateSourcePosition(),
+                )
+            }
+        }
+
+        if (target instanceof PortView) {
+            this.x2 = target.actor.draggableRectangle.left + target.centerX
+            this.y2 = target.actor.draggableRectangle.top + target.centerY
+            sys.whenIntTrackChanged(target.offsetId, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.left, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.top, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.width, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.height, () => this.updateTargetPosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.left, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.top, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.width, () => this.updateSourcePosition())
+            sys.whenIntTrackChanged(target.actor.draggableRectangle.trackedIds.height, () => this.updateSourcePosition())
+        }
+
+        if (target instanceof BusView) {
+            if (target.orientation === A.BusOrientation.Horizontal) {
+                this.x2 = this.getPortViewX(source)
+                this.y2 = target.draggableRectangle.top
+                sys.whenIntTrackChanged(
+                    target.draggableRectangle.trackedIds.top,
+                    () => this.updateTargetPosition(),
+                )
+            }
+            if (target.orientation === A.BusOrientation.Vertical) {
+                this.x2 = target.draggableRectangle.left
+                this.y2 = this.y1
+                sys.whenIntTrackChanged(
+                    target.draggableRectangle.trackedIds.left,
+                    () => this.updateTargetPosition(),
+                )
+            }
+        }
+
+        parentSVG.appendChild(this.line)
+    }
+
+    private get x1() { return this.line.x1.baseVal.value }
+    private set x1(x1: number) { this.line.x1.baseVal.value = x1 }
+    private get x2() { return this.line.x2.baseVal.value }
+    private set x2(x2: number) { this.line.x2.baseVal.value = x2 }
+    private get y1() { return this.line.y1.baseVal.value }
+    private set y1(y1: number) { this.line.y1.baseVal.value = y1 }
+    private get y2() { return this.line.y2.baseVal.value }
+    private set y2(y2: number) { this.line.y2.baseVal.value = y2 }
+
+    /** Remove all components from SVG */
+    dispose(): void {
+        this.line.remove()
+    }
+
+}

--- a/vscode-plugins/architecture/src/webview/views/port.ts
+++ b/vscode-plugins/architecture/src/webview/views/port.ts
@@ -1,0 +1,206 @@
+import * as A from '../../shared/architecture.js'
+import { ChangeSet } from '../changeSet.js'
+import * as D from '../dragHandlers.js'
+import * as svg from '../svg.js'
+import { SystemServices } from '../systemServices.js'
+
+import type { ActorView } from './actor'
+
+export enum PortDir { Out = 'Out', In = 'In' }
+
+/**
+ * Represents a port on a service.
+ */
+export class PortView {
+    border: A.Border
+    readonly borderId: A.TrackIndex
+    // Element we created for port
+    readonly elt: SVGUseElement
+    readonly name: string
+    offset: number
+    readonly offsetId: A.TrackIndex
+
+    get actorSVG(): SVGSVGElement { return this.actor.draggableRectangle.svgContainer }
+
+    /**
+     * Create a new port.
+     */
+    constructor(
+        sys: SystemServices,
+        readonly actor: ActorView,
+        readonly direction: PortDir,
+        p: A.Port
+    ) {
+
+        this.border = p.border.value
+        this.borderId = p.border.trackId
+        this.name = p.name.value
+        this.offset = p.offset.value
+        this.offsetId = p.offset.trackId
+
+        sys.whenIntTrackChanged(this.offsetId, (offset) => {
+            this.offset = offset
+            this.setPortElementPosition()
+        })
+
+        sys.whenTrackedChanged(
+            this.borderId,
+            (s: string) => s as A.Border, // assumes we get a value from the enum
+            (border) => {
+                this.border = border
+                this.setPortElementPosition()
+            },
+        )
+
+        const elt = document.createElementNS(svg.ns, 'use') as SVGUseElement
+        elt.setAttributeNS('', 'href', '#inPort')
+        this.actorSVG.appendChild(elt)
+        this.elt = elt
+
+        const bbox = elt.getBBox()
+
+        this.setPortElementPosition()
+
+        D.addSVGDragHandlers(this.actorSVG, elt, (evt: D.SVGDragEvent) => {
+            // Maximum left value
+            const maxLeft = this.actorSVG.width.baseVal.value - bbox.width
+            // Maximum top value
+            const maxTop = this.actorSVG.height.baseVal.value - bbox.height
+            // Calculate x distance above or below max.
+            const xDist = outsideRangeDist(evt.left, 0, maxLeft)
+            // Calculate y distance above or below max.
+            const yDist = outsideRangeDist(evt.top, 0, maxTop)
+
+            // Figuring out which side of the actor rectangle is closest to evt
+            const distLeft = euclid2Dist(Math.abs(evt.left), yDist)
+            const distRight = euclid2Dist(Math.abs(maxLeft - evt.left), yDist)
+            const distTop = euclid2Dist(Math.abs(evt.top), xDist)
+            const distBottom = euclid2Dist(Math.abs(maxTop - evt.top), xDist)
+            const distMin = Math.min(distLeft, distTop, distRight, distBottom)
+
+            let border: A.Border
+            let offset: number
+            if (distLeft === distMin) {
+                border = A.Border.Left
+                offset = evt.top
+            } else if (distRight === distMin) {
+                border = A.Border.Right
+                offset = evt.top
+            } else if (distTop === distMin) {
+                border = A.Border.Top
+                offset = evt.left
+            } else {
+                border = A.Border.Bottom
+                offset = evt.left
+            }
+            // setPortElementPosition(actorSVG, elt, bbox, portType, border, offset)
+            const changes = new ChangeSet()
+            if (this.border !== border) {
+                changes.replace(p.border.trackId, border)
+            }
+            if (this.offset !== offset) {
+                changes.replace(p.offset.trackId, offset)
+            }
+            sys.sendUpdateDoc(changes)
+        })
+    }
+
+    get centerX(): number {
+        const bbox = this.elt.getBBox()
+        return this.x + bbox.width / 2
+    }
+
+    get centerY(): number {
+        const bbox = this.elt.getBBox()
+        return this.y + bbox.height / 2
+    }
+
+    get x(): number { return this.elt.x.baseVal.value }
+    set x(x: number) { this.elt.x.baseVal.value = x }
+    get y(): number { return this.elt.y.baseVal.value }
+    set y(y: number) { this.elt.y.baseVal.value = y }
+
+    setPortElementPosition(): void {
+        const bbox = this.elt.getBBox()
+
+        // Maximum left value
+        const maxLeft = this.actorSVG.width.baseVal.value - bbox.width
+        // Maximum top value
+        const maxTop = this.actorSVG.height.baseVal.value - bbox.height
+        let offset: number
+        const position = this.offset
+        switch (this.border) {
+            case A.Border.Left:
+                offset = clamp(position, 0, maxTop)
+                this.x = 0
+                this.y = offset
+                break
+            case A.Border.Right:
+                offset = clamp(position, 0, maxTop)
+                this.x = maxLeft
+                this.y = offset
+                break
+            case A.Border.Top:
+                offset = clamp(position, 0, maxLeft)
+                this.x = offset
+                this.y = 0
+                break
+            case A.Border.Bottom:
+                offset = clamp(position, 0, maxLeft)
+                this.x = offset
+                this.y = maxTop
+                break
+        }
+
+        const rotate = calculatePortRotate(this.direction, this.x, maxLeft, this.y, maxTop)
+        this.elt.setAttributeNS('', 'transform', rotateString(rotate, this.centerX, this.centerY))
+    }
+
+}
+
+/** `outsideRangeDist(x,l,h)` returns the amount `x` is outside the range `[l,h]`. */
+function outsideRangeDist(x: number, l: number, h: number): number {
+    if (x < l) { return l - x } else if (x > h) { return h - x } else { return 0 }
+}
+
+/**
+ * `euclid2Dist(x, y)` returns `sqrt(x * x + y * y)`.
+ *
+ * It has special cases and assumes `x` and `y` are non-negative.
+ */
+function euclid2Dist(x: number, y: number) {
+    if (x === 0) { return y } else if (y === 0) { return x } else { return Math.sqrt(x * x + y * y) }
+}
+
+/**
+ * Clamp a number between a minimum and maximum value.
+ */
+function clamp(v: number, min: number, max: number) {
+    return Math.min(Math.max(v, min), max)
+}
+
+/**
+ * Generate rotate string for a SVG CSS transform attribute.
+ */
+function rotateString(rotate: number, xoff: number, yoff: number): string {
+    return `rotate(${rotate.toString()}, ${xoff.toString()}, ${yoff.toString()})`
+}
+
+/**
+ * This calculate the orientation of the
+ */
+function calculatePortRotate(dir: PortDir, left: number, maxLeft: number, top: number, maxTop: number) {
+    let orient: number
+    if (top <= 0) {
+        orient = 0
+    } else if (top < maxTop) {
+        orient = (left <= 0) ? 270 : 90
+    } else {
+        orient = 180
+    }
+
+    const inPort = dir === PortDir.In
+    const angle = inPort ? 90 : 270
+
+    return (orient + angle) % 360
+}


### PR DESCRIPTION
This commit adds basic display of connections.  Because connections coordinates
are relative to that of their endpoints, this required a modification to the
listeners protocol to allow registering multiple listener to the same tracked
identifiers.

This allows separating some concerns, as the connection is responsible for
registering itself as interested in changes to its endpoints, rather than
having the endpoints be concerned with broadcasting their changes to an unknown
set of other components who depend on those values.

We also now send updates to the view who made those changes, since other
components in the same view will be listening.  This actually simplifies the
sender of those changes, as they don't need to do their modification in place
and can listen to the very changes they emit.

There is a bit of code duplication / lack of abstraction in the handling of
endpoints, as they can be either buses or actor ports and we treat those very
differently.  This can likely be improved down the line.

The display is subject to change in future commits: in particular, we will
likely want the line to be displayed under the port, and we will also want the
line to slant if an actor is too far from the bus it is connected to.