### PR TITLE
Check union buffer size against _wire type

### DIFF
--- a/antlr/StructTypeSpec.cpp
+++ b/antlr/StructTypeSpec.cpp
@@ -217,7 +217,7 @@ void StructTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream) {
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
     ostream << "buf" << "." << "resize" << "(";
-    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire)";
+    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire" << ")";
     ostream << ")" << ";" << std::endl;
     ostream << "struct" << " " << namespacePrefix << identifier << "_wire" << "*";
     ostream << " " << "output" << " " << "=" << " ";
@@ -257,7 +257,7 @@ void StructTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     ostream << "(" << "const" << " " << "struct" << " " << namespacePrefix << identifier << "_wire" << "*" << ")";
     ostream << " " << "buf" << "." << "data" << "(" << ")" << ";" << std::endl;
     ostream << "if" << " " << "(" << "buf" << "." << "size" << "(" << ")" << " " << "!=" << " ";
-    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << ")";
+    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire" << ")";
     ostream << ")" << " " << "{" << std::endl;
     ostream << indent_manip::push;
     ostream << "static" << " " << "const" << " " << "std" << "::" << "string" << " ";
@@ -269,7 +269,7 @@ void StructTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     ostream << " type did not receive a buffer of size " << "\"";
     ostream << ")" << " " << "+" << std::endl;
     ostream << "std" << "::" << "to_string" << "(" << "sizeof" << "(";
-    ostream << "struct" << " " << namespacePrefix << identifier << ")" << ")" <<";" << std::endl;
+    ostream << "struct" << " " << namespacePrefix << identifier << "_wire" << ")" << ")" <<";" << std::endl;
     ostream << indent_manip::pop;
     ostream << "throw" << " " << "std" << "::" << "length_error" << "(";
     ostream << "error_msg" << ")" << ";" << std::endl;

--- a/antlr/StructTypeSpec.cpp
+++ b/antlr/StructTypeSpec.cpp
@@ -217,7 +217,7 @@ void StructTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream) {
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
     ostream << "buf" << "." << "resize" << "(";
-    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << ")";
+    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire)";
     ostream << ")" << ";" << std::endl;
     ostream << "struct" << " " << namespacePrefix << identifier << "_wire" << "*";
     ostream << " " << "output" << " " << "=" << " ";

--- a/antlr/UnionTypeSpec.cpp
+++ b/antlr/UnionTypeSpec.cpp
@@ -294,7 +294,7 @@ void UnionTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream) {
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
     ostream << "buf" << "." << "resize" << "(";
-    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << ")";
+    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire)";
     ostream << ")" << ";" << std::endl;
     ostream << "struct" << " " << namespacePrefix << identifier << "_wire" << "*";
     ostream << " " << "output" << " " << "=" << " ";

--- a/antlr/UnionTypeSpec.cpp
+++ b/antlr/UnionTypeSpec.cpp
@@ -294,7 +294,7 @@ void UnionTypeSpec::cppDeclareSerializationFunction(std::ostream &ostream) {
     ostream << " " << "{" << std::endl;
     ostream << indent_manip::push;
     ostream << "buf" << "." << "resize" << "(";
-    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire)";
+    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire" << ")";
     ostream << ")" << ";" << std::endl;
     ostream << "struct" << " " << namespacePrefix << identifier << "_wire" << "*";
     ostream << " " << "output" << " " << "=" << " ";
@@ -330,7 +330,7 @@ void UnionTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     ostream << "(" << "const" << " " << "struct" << " " << namespacePrefix << identifier << "_wire" << "*" << ")";
     ostream << " " << "buf" << "." << "data" << "(" << ")" << ";" << std::endl;
     ostream << "if" << " " << "(" << "buf" << "." << "size" << "(" << ")" << " " << "!=" << " ";
-    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire)";
+    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire" << ")";
     ostream << ")" << " " << "{" << std::endl;
     ostream << indent_manip::push;
     ostream << "static" << " " << "const" << " " << "std" << "::" << "string" << " ";
@@ -342,7 +342,7 @@ void UnionTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     ostream << " type did not receive a buffer of size " << "\"";
     ostream << ")" << " " << "+" << std::endl;
     ostream << "std" << "::" << "to_string" << "(" << "sizeof" << "(";
-    ostream << "struct" << " " << namespacePrefix << identifier << "_wire)" << ")" <<";" << std::endl;
+    ostream << "struct" << " " << namespacePrefix << identifier << "_wire" << ")" << ")" <<";" << std::endl;
     ostream << indent_manip::pop;
     ostream << "throw" << " " << "std" << "::" << "length_error" << "(";
     ostream << "error_msg" << ")" << ";" << std::endl;

--- a/antlr/UnionTypeSpec.cpp
+++ b/antlr/UnionTypeSpec.cpp
@@ -330,7 +330,7 @@ void UnionTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     ostream << "(" << "const" << " " << "struct" << " " << namespacePrefix << identifier << "_wire" << "*" << ")";
     ostream << " " << "buf" << "." << "data" << "(" << ")" << ";" << std::endl;
     ostream << "if" << " " << "(" << "buf" << "." << "size" << "(" << ")" << " " << "!=" << " ";
-    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << ")";
+    ostream << "sizeof(" << "struct" << " " << namespacePrefix << identifier << "_wire)";
     ostream << ")" << " " << "{" << std::endl;
     ostream << indent_manip::push;
     ostream << "static" << " " << "const" << " " << "std" << "::" << "string" << " ";
@@ -342,7 +342,7 @@ void UnionTypeSpec::cppDeclareDeserializationFunction(std::ostream &ostream) {
     ostream << " type did not receive a buffer of size " << "\"";
     ostream << ")" << " " << "+" << std::endl;
     ostream << "std" << "::" << "to_string" << "(" << "sizeof" << "(";
-    ostream << "struct" << " " << namespacePrefix << identifier << ")" << ")" <<";" << std::endl;
+    ostream << "struct" << " " << namespacePrefix << identifier << "_wire)" << ")" <<";" << std::endl;
     ostream << indent_manip::pop;
     ostream << "throw" << " " << "std" << "::" << "length_error" << "(";
     ostream << "error_msg" << ")" << ";" << std::endl;

--- a/antlr/indent_facet.hpp
+++ b/antlr/indent_facet.hpp
@@ -47,7 +47,7 @@ inline indent_facet::result indent_facet::do_out(state_type &need_indentation,
 		if ((state(need_indentation) == 0) && (*from != '\n')) {
 			res = std::codecvt_base::ok;
 			state(need_indentation) = 1;
-			for(int i=0; i<m_indentation_level; ++i){
+			for(int i=0; i<m_indentation_level && to+1 < to_end; ++i){
 				*to = '\t'; ++to;
 			}
 			if (to == to_end) {

--- a/antlr/indent_facet.hpp
+++ b/antlr/indent_facet.hpp
@@ -47,10 +47,10 @@ inline indent_facet::result indent_facet::do_out(state_type &need_indentation,
 		if ((state(need_indentation) == 0) && (*from != '\n')) {
 			res = std::codecvt_base::ok;
 			state(need_indentation) = 1;
-			for(int i=0; i<m_indentation_level && to+1 < to_end; ++i){
+			for(int i=0; i<m_indentation_level; ++i){
 				*to = '\t'; ++to;
 			}
-			if (to == to_end) {
+			if (to >= to_end) {
 				res = std::codecvt_base::partial;
 				break;
 			}

--- a/antlr/test/output/cpp/annotations.cpp
+++ b/antlr/test/output/cpp/annotations.cpp
@@ -121,10 +121,10 @@ namespace pirate {
 
 		static struct Annotations_Module::Annotation_Struct_Example fromBuffer(std::vector<char> const& buf) {
 			const struct Annotations_Module::Annotation_Struct_Example_wire* input = (const struct Annotations_Module::Annotation_Struct_Example_wire*) buf.data();
-			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Struct_Example)) {
+			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Struct_Example_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Annotations_Module::Annotation_Struct_Example type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Annotations_Module::Annotation_Struct_Example));
+					std::to_string(sizeof(struct Annotations_Module::Annotation_Struct_Example_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/annotations.cpp
+++ b/antlr/test/output/cpp/annotations.cpp
@@ -113,7 +113,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Annotations_Module::Annotation_Struct_Example> {
 		static void toBuffer(struct Annotations_Module::Annotation_Struct_Example const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Annotations_Module::Annotation_Struct_Example));
+			buf.resize(sizeof(struct Annotations_Module::Annotation_Struct_Example_wire));
 			struct Annotations_Module::Annotation_Struct_Example_wire* output = (struct Annotations_Module::Annotation_Struct_Example_wire*) buf.data();
 			const struct Annotations_Module::Annotation_Struct_Example* input = &val;
 			toWireType(input, output);
@@ -196,7 +196,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Annotations_Module::Annotation_Union_Example> {
 		static void toBuffer(struct Annotations_Module::Annotation_Union_Example const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Annotations_Module::Annotation_Union_Example));
+			buf.resize(sizeof(struct Annotations_Module::Annotation_Union_Example_wire));
 			struct Annotations_Module::Annotation_Union_Example_wire* output = (struct Annotations_Module::Annotation_Union_Example_wire*) buf.data();
 			const struct Annotations_Module::Annotation_Union_Example* input = &val;
 			toWireType(input, output);
@@ -204,10 +204,10 @@ namespace pirate {
 
 		static struct Annotations_Module::Annotation_Union_Example fromBuffer(std::vector<char> const& buf) {
 			const struct Annotations_Module::Annotation_Union_Example_wire* input = (const struct Annotations_Module::Annotation_Union_Example_wire*) buf.data();
-			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Union_Example)) {
+			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Union_Example_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Annotations_Module::Annotation_Union_Example type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Annotations_Module::Annotation_Union_Example));
+					std::to_string(sizeof(struct Annotations_Module::Annotation_Union_Example_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/arrays.cpp
+++ b/antlr/test/output/cpp/arrays.cpp
@@ -179,3 +179,76 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
+							const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
+							unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+							memcpy(&field_c, inptr, sizeof(uint32_t));
+							field_c = htobe32(field_c);
+							memcpy(outptr, &field_c, sizeof(uint32_t));
+							}
+						}
+					}
+				}
+			}
+		}
+		memcpy(&field_a, &input->a, sizeof(uint8_t));
+		memcpy(&output->a, &field_a, sizeof(uint8_t));
+	}
+
+	inline struct Arrays::Struct_Array_Field fromWireType(const struct Arrays::Struct_Array_Field_wire* input) {
+		struct Arrays::Struct_Array_Field retval;
+		struct Arrays::Struct_Array_Field* output = &retval;
+		uint8_t field_a;
+		uint32_t field_b;
+		uint32_t field_c;
+		for (size_t b_0 = 0; b_0 < 10; b_0++) {
+			const unsigned char* inptr = &input->b[b_0][0];
+			int32_t* outptr = &output->b[b_0];
+			memcpy(&field_b, inptr, sizeof(uint32_t));
+			field_b = be32toh(field_b);
+			memcpy(outptr, &field_b, sizeof(uint32_t));
+		}
+		for (size_t c_0 = 0; c_0 < 1; c_0++) {
+			for (size_t c_1 = 0; c_1 < 2; c_1++) {
+				for (size_t c_2 = 0; c_2 < 3; c_2++) {
+					for (size_t c_3 = 0; c_3 < 4; c_3++) {
+						for (size_t c_4 = 0; c_4 < 5; c_4++) {
+							for (size_t c_5 = 0; c_5 < 6; c_5++) {
+							const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+							float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
+							memcpy(&field_c, inptr, sizeof(uint32_t));
+							field_c = be32toh(field_c);
+							memcpy(outptr, &field_c, sizeof(uint32_t));
+							}
+						}
+					}
+				}
+			}
+		}
+		memcpy(&field_a, &input->a, sizeof(uint8_t));
+		memcpy(&output->a, &field_a, sizeof(uint8_t));
+		return retval;
+	}
+
+	template<>
+	struct Serialization<struct Arrays::Struct_Array_Field> {
+		static void toBuffer(struct Arrays::Struct_Array_Field const& val, std::vector<char>& buf) {
+			buf.resize(sizeof(struct Arrays::Struct_Array_Field_wire));
+			struct Arrays::Struct_Array_Field_wire* output = (struct Arrays::Struct_Array_Field_wire*) buf.data();
+			const struct Arrays::Struct_Array_Field* input = &val;
+			toWireType(input, output);
+		}
+
+		static struct Arrays::Struct_Array_Field fromBuffer(std::vector<char> const& buf) {
+			const struct Arrays::Struct_Array_Field_wire* input = (const struct Arrays::Struct_Array_Field_wire*) buf.data();
+			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field)) {
+				static const std::string error_msg =
+					std::string("pirate::Serialization::fromBuffer() for Arrays::Struct_Array_Field type did not receive a buffer of size ") +
+					std::to_string(sizeof(struct Arrays::Struct_Array_Field));
+				throw std::length_error(error_msg);
+			}
+			return fromWireType(input);
+		}
+	};
+}
+
+#endif // _ARRAYS_IDL_CODEGEN_H

--- a/antlr/test/output/cpp/arrays.cpp
+++ b/antlr/test/output/cpp/arrays.cpp
@@ -179,11 +179,11 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-							const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
-							unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-							memcpy(&field_c, inptr, sizeof(uint32_t));
-							field_c = htobe32(field_c);
-							memcpy(outptr, &field_c, sizeof(uint32_t));
+								const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
+								unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+								memcpy(&field_c, inptr, sizeof(uint32_t));
+								field_c = htobe32(field_c);
+								memcpy(outptr, &field_c, sizeof(uint32_t));
 							}
 						}
 					}

--- a/antlr/test/output/cpp/arrays.cpp
+++ b/antlr/test/output/cpp/arrays.cpp
@@ -213,11 +213,11 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-							const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-							float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
-							memcpy(&field_c, inptr, sizeof(uint32_t));
-							field_c = be32toh(field_c);
-							memcpy(outptr, &field_c, sizeof(uint32_t));
+								const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+								float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
+								memcpy(&field_c, inptr, sizeof(uint32_t));
+								field_c = be32toh(field_c);
+								memcpy(outptr, &field_c, sizeof(uint32_t));
 							}
 						}
 					}

--- a/antlr/test/output/cpp/arrays.cpp
+++ b/antlr/test/output/cpp/arrays.cpp
@@ -240,10 +240,10 @@ namespace pirate {
 
 		static struct Arrays::Struct_Array_Field fromBuffer(std::vector<char> const& buf) {
 			const struct Arrays::Struct_Array_Field_wire* input = (const struct Arrays::Struct_Array_Field_wire*) buf.data();
-			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field)) {
+			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Arrays::Struct_Array_Field type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Arrays::Struct_Array_Field));
+					std::to_string(sizeof(struct Arrays::Struct_Array_Field_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/arrays.cpp
+++ b/antlr/test/output/cpp/arrays.cpp
@@ -143,7 +143,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Arrays::Union_Array_Field> {
 		static void toBuffer(struct Arrays::Union_Array_Field const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Arrays::Union_Array_Field));
+			buf.resize(sizeof(struct Arrays::Union_Array_Field_wire));
 			struct Arrays::Union_Array_Field_wire* output = (struct Arrays::Union_Array_Field_wire*) buf.data();
 			const struct Arrays::Union_Array_Field* input = &val;
 			toWireType(input, output);
@@ -151,10 +151,10 @@ namespace pirate {
 
 		static struct Arrays::Union_Array_Field fromBuffer(std::vector<char> const& buf) {
 			const struct Arrays::Union_Array_Field_wire* input = (const struct Arrays::Union_Array_Field_wire*) buf.data();
-			if (buf.size() != sizeof(struct Arrays::Union_Array_Field)) {
+			if (buf.size() != sizeof(struct Arrays::Union_Array_Field_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Arrays::Union_Array_Field type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Arrays::Union_Array_Field));
+					std::to_string(sizeof(struct Arrays::Union_Array_Field_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -179,76 +179,3 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-								const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
-								unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-								memcpy(&field_c, inptr, sizeof(uint32_t));
-								field_c = htobe32(field_c);
-								memcpy(outptr, &field_c, sizeof(uint32_t));
-							}
-						}
-					}
-				}
-			}
-		}
-		memcpy(&field_a, &input->a, sizeof(uint8_t));
-		memcpy(&output->a, &field_a, sizeof(uint8_t));
-	}
-
-	inline struct Arrays::Struct_Array_Field fromWireType(const struct Arrays::Struct_Array_Field_wire* input) {
-		struct Arrays::Struct_Array_Field retval;
-		struct Arrays::Struct_Array_Field* output = &retval;
-		uint8_t field_a;
-		uint32_t field_b;
-		uint32_t field_c;
-		for (size_t b_0 = 0; b_0 < 10; b_0++) {
-			const unsigned char* inptr = &input->b[b_0][0];
-			int32_t* outptr = &output->b[b_0];
-			memcpy(&field_b, inptr, sizeof(uint32_t));
-			field_b = be32toh(field_b);
-			memcpy(outptr, &field_b, sizeof(uint32_t));
-		}
-		for (size_t c_0 = 0; c_0 < 1; c_0++) {
-			for (size_t c_1 = 0; c_1 < 2; c_1++) {
-				for (size_t c_2 = 0; c_2 < 3; c_2++) {
-					for (size_t c_3 = 0; c_3 < 4; c_3++) {
-						for (size_t c_4 = 0; c_4 < 5; c_4++) {
-							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-								const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-								float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
-								memcpy(&field_c, inptr, sizeof(uint32_t));
-								field_c = be32toh(field_c);
-								memcpy(outptr, &field_c, sizeof(uint32_t));
-							}
-						}
-					}
-				}
-			}
-		}
-		memcpy(&field_a, &input->a, sizeof(uint8_t));
-		memcpy(&output->a, &field_a, sizeof(uint8_t));
-		return retval;
-	}
-
-	template<>
-	struct Serialization<struct Arrays::Struct_Array_Field> {
-		static void toBuffer(struct Arrays::Struct_Array_Field const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Arrays::Struct_Array_Field));
-			struct Arrays::Struct_Array_Field_wire* output = (struct Arrays::Struct_Array_Field_wire*) buf.data();
-			const struct Arrays::Struct_Array_Field* input = &val;
-			toWireType(input, output);
-		}
-
-		static struct Arrays::Struct_Array_Field fromBuffer(std::vector<char> const& buf) {
-			const struct Arrays::Struct_Array_Field_wire* input = (const struct Arrays::Struct_Array_Field_wire*) buf.data();
-			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field)) {
-				static const std::string error_msg =
-					std::string("pirate::Serialization::fromBuffer() for Arrays::Struct_Array_Field type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Arrays::Struct_Array_Field));
-				throw std::length_error(error_msg);
-			}
-			return fromWireType(input);
-		}
-	};
-}
-
-#endif // _ARRAYS_IDL_CODEGEN_H

--- a/antlr/test/output/cpp/enum.cpp
+++ b/antlr/test/output/cpp/enum.cpp
@@ -79,10 +79,10 @@ namespace pirate {
 
 		static struct EnumType::Week_Interval fromBuffer(std::vector<char> const& buf) {
 			const struct EnumType::Week_Interval_wire* input = (const struct EnumType::Week_Interval_wire*) buf.data();
-			if (buf.size() != sizeof(struct EnumType::Week_Interval)) {
+			if (buf.size() != sizeof(struct EnumType::Week_Interval_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for EnumType::Week_Interval type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct EnumType::Week_Interval));
+					std::to_string(sizeof(struct EnumType::Week_Interval_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/enum.cpp
+++ b/antlr/test/output/cpp/enum.cpp
@@ -71,7 +71,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct EnumType::Week_Interval> {
 		static void toBuffer(struct EnumType::Week_Interval const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct EnumType::Week_Interval));
+			buf.resize(sizeof(struct EnumType::Week_Interval_wire));
 			struct EnumType::Week_Interval_wire* output = (struct EnumType::Week_Interval_wire*) buf.data();
 			const struct EnumType::Week_Interval* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/nested.cpp
+++ b/antlr/test/output/cpp/nested.cpp
@@ -161,10 +161,10 @@ namespace pirate {
 
 		static struct NestedTypes::Foo fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::Foo_wire* input = (const struct NestedTypes::Foo_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::Foo)) {
+			if (buf.size() != sizeof(struct NestedTypes::Foo_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::Foo type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::Foo));
+					std::to_string(sizeof(struct NestedTypes::Foo_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -216,10 +216,10 @@ namespace pirate {
 
 		static struct NestedTypes::Bar fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::Bar_wire* input = (const struct NestedTypes::Bar_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::Bar)) {
+			if (buf.size() != sizeof(struct NestedTypes::Bar_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::Bar type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::Bar));
+					std::to_string(sizeof(struct NestedTypes::Bar_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -291,10 +291,10 @@ namespace pirate {
 
 		static struct NestedTypes::OuterStruct fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::OuterStruct_wire* input = (const struct NestedTypes::OuterStruct_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::OuterStruct)) {
+			if (buf.size() != sizeof(struct NestedTypes::OuterStruct_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::OuterStruct type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::OuterStruct));
+					std::to_string(sizeof(struct NestedTypes::OuterStruct_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/nested.cpp
+++ b/antlr/test/output/cpp/nested.cpp
@@ -153,7 +153,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::Foo> {
 		static void toBuffer(struct NestedTypes::Foo const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::Foo));
+			buf.resize(sizeof(struct NestedTypes::Foo_wire));
 			struct NestedTypes::Foo_wire* output = (struct NestedTypes::Foo_wire*) buf.data();
 			const struct NestedTypes::Foo* input = &val;
 			toWireType(input, output);
@@ -208,7 +208,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::Bar> {
 		static void toBuffer(struct NestedTypes::Bar const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::Bar));
+			buf.resize(sizeof(struct NestedTypes::Bar_wire));
 			struct NestedTypes::Bar_wire* output = (struct NestedTypes::Bar_wire*) buf.data();
 			const struct NestedTypes::Bar* input = &val;
 			toWireType(input, output);
@@ -283,7 +283,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::OuterStruct> {
 		static void toBuffer(struct NestedTypes::OuterStruct const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::OuterStruct));
+			buf.resize(sizeof(struct NestedTypes::OuterStruct_wire));
 			struct NestedTypes::OuterStruct_wire* output = (struct NestedTypes::OuterStruct_wire*) buf.data();
 			const struct NestedTypes::OuterStruct* input = &val;
 			toWireType(input, output);
@@ -388,7 +388,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::OuterUnion> {
 		static void toBuffer(struct NestedTypes::OuterUnion const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::OuterUnion));
+			buf.resize(sizeof(struct NestedTypes::OuterUnion_wire));
 			struct NestedTypes::OuterUnion_wire* output = (struct NestedTypes::OuterUnion_wire*) buf.data();
 			const struct NestedTypes::OuterUnion* input = &val;
 			toWireType(input, output);
@@ -396,10 +396,10 @@ namespace pirate {
 
 		static struct NestedTypes::OuterUnion fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::OuterUnion_wire* input = (const struct NestedTypes::OuterUnion_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::OuterUnion)) {
+			if (buf.size() != sizeof(struct NestedTypes::OuterUnion_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::OuterUnion type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::OuterUnion));
+					std::to_string(sizeof(struct NestedTypes::OuterUnion_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -493,7 +493,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::ScopedOuterUnion> {
 		static void toBuffer(struct NestedTypes::ScopedOuterUnion const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::ScopedOuterUnion));
+			buf.resize(sizeof(struct NestedTypes::ScopedOuterUnion_wire));
 			struct NestedTypes::ScopedOuterUnion_wire* output = (struct NestedTypes::ScopedOuterUnion_wire*) buf.data();
 			const struct NestedTypes::ScopedOuterUnion* input = &val;
 			toWireType(input, output);
@@ -501,10 +501,10 @@ namespace pirate {
 
 		static struct NestedTypes::ScopedOuterUnion fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::ScopedOuterUnion_wire* input = (const struct NestedTypes::ScopedOuterUnion_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::ScopedOuterUnion)) {
+			if (buf.size() != sizeof(struct NestedTypes::ScopedOuterUnion_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::ScopedOuterUnion type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::ScopedOuterUnion));
+					std::to_string(sizeof(struct NestedTypes::ScopedOuterUnion_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/annotations.cpp
+++ b/antlr/test/output/cpp/packed/annotations.cpp
@@ -117,10 +117,10 @@ namespace pirate {
 
 		static struct Annotations_Module::Annotation_Struct_Example fromBuffer(std::vector<char> const& buf) {
 			const struct Annotations_Module::Annotation_Struct_Example_wire* input = (const struct Annotations_Module::Annotation_Struct_Example_wire*) buf.data();
-			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Struct_Example)) {
+			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Struct_Example_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Annotations_Module::Annotation_Struct_Example type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Annotations_Module::Annotation_Struct_Example));
+					std::to_string(sizeof(struct Annotations_Module::Annotation_Struct_Example_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/annotations.cpp
+++ b/antlr/test/output/cpp/packed/annotations.cpp
@@ -109,7 +109,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Annotations_Module::Annotation_Struct_Example> {
 		static void toBuffer(struct Annotations_Module::Annotation_Struct_Example const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Annotations_Module::Annotation_Struct_Example));
+			buf.resize(sizeof(struct Annotations_Module::Annotation_Struct_Example_wire));
 			struct Annotations_Module::Annotation_Struct_Example_wire* output = (struct Annotations_Module::Annotation_Struct_Example_wire*) buf.data();
 			const struct Annotations_Module::Annotation_Struct_Example* input = &val;
 			toWireType(input, output);
@@ -192,7 +192,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Annotations_Module::Annotation_Union_Example> {
 		static void toBuffer(struct Annotations_Module::Annotation_Union_Example const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Annotations_Module::Annotation_Union_Example));
+			buf.resize(sizeof(struct Annotations_Module::Annotation_Union_Example_wire));
 			struct Annotations_Module::Annotation_Union_Example_wire* output = (struct Annotations_Module::Annotation_Union_Example_wire*) buf.data();
 			const struct Annotations_Module::Annotation_Union_Example* input = &val;
 			toWireType(input, output);
@@ -200,10 +200,10 @@ namespace pirate {
 
 		static struct Annotations_Module::Annotation_Union_Example fromBuffer(std::vector<char> const& buf) {
 			const struct Annotations_Module::Annotation_Union_Example_wire* input = (const struct Annotations_Module::Annotation_Union_Example_wire*) buf.data();
-			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Union_Example)) {
+			if (buf.size() != sizeof(struct Annotations_Module::Annotation_Union_Example_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Annotations_Module::Annotation_Union_Example type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Annotations_Module::Annotation_Union_Example));
+					std::to_string(sizeof(struct Annotations_Module::Annotation_Union_Example_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/arrays.cpp
+++ b/antlr/test/output/cpp/packed/arrays.cpp
@@ -175,11 +175,11 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-							const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
-							unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-							memcpy(&field_c, inptr, sizeof(uint32_t));
-							field_c = htobe32(field_c);
-							memcpy(outptr, &field_c, sizeof(uint32_t));
+								const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
+								unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+								memcpy(&field_c, inptr, sizeof(uint32_t));
+								field_c = htobe32(field_c);
+								memcpy(outptr, &field_c, sizeof(uint32_t));
 							}
 						}
 					}

--- a/antlr/test/output/cpp/packed/arrays.cpp
+++ b/antlr/test/output/cpp/packed/arrays.cpp
@@ -209,11 +209,11 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-							const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-							float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
-							memcpy(&field_c, inptr, sizeof(uint32_t));
-							field_c = be32toh(field_c);
-							memcpy(outptr, &field_c, sizeof(uint32_t));
+								const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+								float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
+								memcpy(&field_c, inptr, sizeof(uint32_t));
+								field_c = be32toh(field_c);
+								memcpy(outptr, &field_c, sizeof(uint32_t));
 							}
 						}
 					}

--- a/antlr/test/output/cpp/packed/arrays.cpp
+++ b/antlr/test/output/cpp/packed/arrays.cpp
@@ -236,10 +236,10 @@ namespace pirate {
 
 		static struct Arrays::Struct_Array_Field fromBuffer(std::vector<char> const& buf) {
 			const struct Arrays::Struct_Array_Field_wire* input = (const struct Arrays::Struct_Array_Field_wire*) buf.data();
-			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field)) {
+			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Arrays::Struct_Array_Field type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Arrays::Struct_Array_Field));
+					std::to_string(sizeof(struct Arrays::Struct_Array_Field_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/arrays.cpp
+++ b/antlr/test/output/cpp/packed/arrays.cpp
@@ -175,3 +175,76 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
+							const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
+							unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+							memcpy(&field_c, inptr, sizeof(uint32_t));
+							field_c = htobe32(field_c);
+							memcpy(outptr, &field_c, sizeof(uint32_t));
+							}
+						}
+					}
+				}
+			}
+		}
+		memcpy(&field_a, &input->a, sizeof(uint8_t));
+		memcpy(&output->a, &field_a, sizeof(uint8_t));
+	}
+
+	inline struct Arrays::Struct_Array_Field fromWireType(const struct Arrays::Struct_Array_Field_wire* input) {
+		struct Arrays::Struct_Array_Field retval;
+		struct Arrays::Struct_Array_Field* output = &retval;
+		uint8_t field_a;
+		uint32_t field_b;
+		uint32_t field_c;
+		for (size_t b_0 = 0; b_0 < 10; b_0++) {
+			const unsigned char* inptr = &input->b[b_0][0];
+			int32_t* outptr = &output->b[b_0];
+			memcpy(&field_b, inptr, sizeof(uint32_t));
+			field_b = be32toh(field_b);
+			memcpy(outptr, &field_b, sizeof(uint32_t));
+		}
+		for (size_t c_0 = 0; c_0 < 1; c_0++) {
+			for (size_t c_1 = 0; c_1 < 2; c_1++) {
+				for (size_t c_2 = 0; c_2 < 3; c_2++) {
+					for (size_t c_3 = 0; c_3 < 4; c_3++) {
+						for (size_t c_4 = 0; c_4 < 5; c_4++) {
+							for (size_t c_5 = 0; c_5 < 6; c_5++) {
+							const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
+							float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
+							memcpy(&field_c, inptr, sizeof(uint32_t));
+							field_c = be32toh(field_c);
+							memcpy(outptr, &field_c, sizeof(uint32_t));
+							}
+						}
+					}
+				}
+			}
+		}
+		memcpy(&field_a, &input->a, sizeof(uint8_t));
+		memcpy(&output->a, &field_a, sizeof(uint8_t));
+		return retval;
+	}
+
+	template<>
+	struct Serialization<struct Arrays::Struct_Array_Field> {
+		static void toBuffer(struct Arrays::Struct_Array_Field const& val, std::vector<char>& buf) {
+			buf.resize(sizeof(struct Arrays::Struct_Array_Field_wire));
+			struct Arrays::Struct_Array_Field_wire* output = (struct Arrays::Struct_Array_Field_wire*) buf.data();
+			const struct Arrays::Struct_Array_Field* input = &val;
+			toWireType(input, output);
+		}
+
+		static struct Arrays::Struct_Array_Field fromBuffer(std::vector<char> const& buf) {
+			const struct Arrays::Struct_Array_Field_wire* input = (const struct Arrays::Struct_Array_Field_wire*) buf.data();
+			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field)) {
+				static const std::string error_msg =
+					std::string("pirate::Serialization::fromBuffer() for Arrays::Struct_Array_Field type did not receive a buffer of size ") +
+					std::to_string(sizeof(struct Arrays::Struct_Array_Field));
+				throw std::length_error(error_msg);
+			}
+			return fromWireType(input);
+		}
+	};
+}
+
+#endif // _ARRAYS_IDL_CODEGEN_H

--- a/antlr/test/output/cpp/packed/arrays.cpp
+++ b/antlr/test/output/cpp/packed/arrays.cpp
@@ -140,7 +140,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Arrays::Union_Array_Field> {
 		static void toBuffer(struct Arrays::Union_Array_Field const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Arrays::Union_Array_Field));
+			buf.resize(sizeof(struct Arrays::Union_Array_Field_wire));
 			struct Arrays::Union_Array_Field_wire* output = (struct Arrays::Union_Array_Field_wire*) buf.data();
 			const struct Arrays::Union_Array_Field* input = &val;
 			toWireType(input, output);
@@ -148,10 +148,10 @@ namespace pirate {
 
 		static struct Arrays::Union_Array_Field fromBuffer(std::vector<char> const& buf) {
 			const struct Arrays::Union_Array_Field_wire* input = (const struct Arrays::Union_Array_Field_wire*) buf.data();
-			if (buf.size() != sizeof(struct Arrays::Union_Array_Field)) {
+			if (buf.size() != sizeof(struct Arrays::Union_Array_Field_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Arrays::Union_Array_Field type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Arrays::Union_Array_Field));
+					std::to_string(sizeof(struct Arrays::Union_Array_Field_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -175,76 +175,3 @@ namespace pirate {
 					for (size_t c_3 = 0; c_3 < 4; c_3++) {
 						for (size_t c_4 = 0; c_4 < 5; c_4++) {
 							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-								const float* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5];
-								unsigned char* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-								memcpy(&field_c, inptr, sizeof(uint32_t));
-								field_c = htobe32(field_c);
-								memcpy(outptr, &field_c, sizeof(uint32_t));
-							}
-						}
-					}
-				}
-			}
-		}
-		memcpy(&field_a, &input->a, sizeof(uint8_t));
-		memcpy(&output->a, &field_a, sizeof(uint8_t));
-	}
-
-	inline struct Arrays::Struct_Array_Field fromWireType(const struct Arrays::Struct_Array_Field_wire* input) {
-		struct Arrays::Struct_Array_Field retval;
-		struct Arrays::Struct_Array_Field* output = &retval;
-		uint8_t field_a;
-		uint32_t field_b;
-		uint32_t field_c;
-		for (size_t b_0 = 0; b_0 < 10; b_0++) {
-			const unsigned char* inptr = &input->b[b_0][0];
-			int32_t* outptr = &output->b[b_0];
-			memcpy(&field_b, inptr, sizeof(uint32_t));
-			field_b = be32toh(field_b);
-			memcpy(outptr, &field_b, sizeof(uint32_t));
-		}
-		for (size_t c_0 = 0; c_0 < 1; c_0++) {
-			for (size_t c_1 = 0; c_1 < 2; c_1++) {
-				for (size_t c_2 = 0; c_2 < 3; c_2++) {
-					for (size_t c_3 = 0; c_3 < 4; c_3++) {
-						for (size_t c_4 = 0; c_4 < 5; c_4++) {
-							for (size_t c_5 = 0; c_5 < 6; c_5++) {
-								const unsigned char* inptr = &input->c[c_0][c_1][c_2][c_3][c_4][c_5][0];
-								float* outptr = &output->c[c_0][c_1][c_2][c_3][c_4][c_5];
-								memcpy(&field_c, inptr, sizeof(uint32_t));
-								field_c = be32toh(field_c);
-								memcpy(outptr, &field_c, sizeof(uint32_t));
-							}
-						}
-					}
-				}
-			}
-		}
-		memcpy(&field_a, &input->a, sizeof(uint8_t));
-		memcpy(&output->a, &field_a, sizeof(uint8_t));
-		return retval;
-	}
-
-	template<>
-	struct Serialization<struct Arrays::Struct_Array_Field> {
-		static void toBuffer(struct Arrays::Struct_Array_Field const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Arrays::Struct_Array_Field));
-			struct Arrays::Struct_Array_Field_wire* output = (struct Arrays::Struct_Array_Field_wire*) buf.data();
-			const struct Arrays::Struct_Array_Field* input = &val;
-			toWireType(input, output);
-		}
-
-		static struct Arrays::Struct_Array_Field fromBuffer(std::vector<char> const& buf) {
-			const struct Arrays::Struct_Array_Field_wire* input = (const struct Arrays::Struct_Array_Field_wire*) buf.data();
-			if (buf.size() != sizeof(struct Arrays::Struct_Array_Field)) {
-				static const std::string error_msg =
-					std::string("pirate::Serialization::fromBuffer() for Arrays::Struct_Array_Field type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Arrays::Struct_Array_Field));
-				throw std::length_error(error_msg);
-			}
-			return fromWireType(input);
-		}
-	};
-}
-
-#endif // _ARRAYS_IDL_CODEGEN_H

--- a/antlr/test/output/cpp/packed/enum.cpp
+++ b/antlr/test/output/cpp/packed/enum.cpp
@@ -77,10 +77,10 @@ namespace pirate {
 
 		static struct EnumType::Week_Interval fromBuffer(std::vector<char> const& buf) {
 			const struct EnumType::Week_Interval_wire* input = (const struct EnumType::Week_Interval_wire*) buf.data();
-			if (buf.size() != sizeof(struct EnumType::Week_Interval)) {
+			if (buf.size() != sizeof(struct EnumType::Week_Interval_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for EnumType::Week_Interval type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct EnumType::Week_Interval));
+					std::to_string(sizeof(struct EnumType::Week_Interval_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/enum.cpp
+++ b/antlr/test/output/cpp/packed/enum.cpp
@@ -69,7 +69,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct EnumType::Week_Interval> {
 		static void toBuffer(struct EnumType::Week_Interval const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct EnumType::Week_Interval));
+			buf.resize(sizeof(struct EnumType::Week_Interval_wire));
 			struct EnumType::Week_Interval_wire* output = (struct EnumType::Week_Interval_wire*) buf.data();
 			const struct EnumType::Week_Interval* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/packed/nested.cpp
+++ b/antlr/test/output/cpp/packed/nested.cpp
@@ -145,7 +145,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::Foo> {
 		static void toBuffer(struct NestedTypes::Foo const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::Foo));
+			buf.resize(sizeof(struct NestedTypes::Foo_wire));
 			struct NestedTypes::Foo_wire* output = (struct NestedTypes::Foo_wire*) buf.data();
 			const struct NestedTypes::Foo* input = &val;
 			toWireType(input, output);
@@ -199,7 +199,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::Bar> {
 		static void toBuffer(struct NestedTypes::Bar const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::Bar));
+			buf.resize(sizeof(struct NestedTypes::Bar_wire));
 			struct NestedTypes::Bar_wire* output = (struct NestedTypes::Bar_wire*) buf.data();
 			const struct NestedTypes::Bar* input = &val;
 			toWireType(input, output);
@@ -273,7 +273,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::OuterStruct> {
 		static void toBuffer(struct NestedTypes::OuterStruct const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::OuterStruct));
+			buf.resize(sizeof(struct NestedTypes::OuterStruct_wire));
 			struct NestedTypes::OuterStruct_wire* output = (struct NestedTypes::OuterStruct_wire*) buf.data();
 			const struct NestedTypes::OuterStruct* input = &val;
 			toWireType(input, output);
@@ -378,7 +378,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::OuterUnion> {
 		static void toBuffer(struct NestedTypes::OuterUnion const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::OuterUnion));
+			buf.resize(sizeof(struct NestedTypes::OuterUnion_wire));
 			struct NestedTypes::OuterUnion_wire* output = (struct NestedTypes::OuterUnion_wire*) buf.data();
 			const struct NestedTypes::OuterUnion* input = &val;
 			toWireType(input, output);
@@ -386,10 +386,10 @@ namespace pirate {
 
 		static struct NestedTypes::OuterUnion fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::OuterUnion_wire* input = (const struct NestedTypes::OuterUnion_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::OuterUnion)) {
+			if (buf.size() != sizeof(struct NestedTypes::OuterUnion_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::OuterUnion type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::OuterUnion));
+					std::to_string(sizeof(struct NestedTypes::OuterUnion_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -483,7 +483,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct NestedTypes::ScopedOuterUnion> {
 		static void toBuffer(struct NestedTypes::ScopedOuterUnion const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct NestedTypes::ScopedOuterUnion));
+			buf.resize(sizeof(struct NestedTypes::ScopedOuterUnion_wire));
 			struct NestedTypes::ScopedOuterUnion_wire* output = (struct NestedTypes::ScopedOuterUnion_wire*) buf.data();
 			const struct NestedTypes::ScopedOuterUnion* input = &val;
 			toWireType(input, output);
@@ -491,10 +491,10 @@ namespace pirate {
 
 		static struct NestedTypes::ScopedOuterUnion fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::ScopedOuterUnion_wire* input = (const struct NestedTypes::ScopedOuterUnion_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::ScopedOuterUnion)) {
+			if (buf.size() != sizeof(struct NestedTypes::ScopedOuterUnion_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::ScopedOuterUnion type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::ScopedOuterUnion));
+					std::to_string(sizeof(struct NestedTypes::ScopedOuterUnion_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/nested.cpp
+++ b/antlr/test/output/cpp/packed/nested.cpp
@@ -153,10 +153,10 @@ namespace pirate {
 
 		static struct NestedTypes::Foo fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::Foo_wire* input = (const struct NestedTypes::Foo_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::Foo)) {
+			if (buf.size() != sizeof(struct NestedTypes::Foo_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::Foo type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::Foo));
+					std::to_string(sizeof(struct NestedTypes::Foo_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -207,10 +207,10 @@ namespace pirate {
 
 		static struct NestedTypes::Bar fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::Bar_wire* input = (const struct NestedTypes::Bar_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::Bar)) {
+			if (buf.size() != sizeof(struct NestedTypes::Bar_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::Bar type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::Bar));
+					std::to_string(sizeof(struct NestedTypes::Bar_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -281,10 +281,10 @@ namespace pirate {
 
 		static struct NestedTypes::OuterStruct fromBuffer(std::vector<char> const& buf) {
 			const struct NestedTypes::OuterStruct_wire* input = (const struct NestedTypes::OuterStruct_wire*) buf.data();
-			if (buf.size() != sizeof(struct NestedTypes::OuterStruct)) {
+			if (buf.size() != sizeof(struct NestedTypes::OuterStruct_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for NestedTypes::OuterStruct type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct NestedTypes::OuterStruct));
+					std::to_string(sizeof(struct NestedTypes::OuterStruct_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/pnt.cpp
+++ b/antlr/test/output/cpp/packed/pnt.cpp
@@ -91,10 +91,10 @@ namespace pirate {
 
 		static struct PNT::Position fromBuffer(std::vector<char> const& buf) {
 			const struct PNT::Position_wire* input = (const struct PNT::Position_wire*) buf.data();
-			if (buf.size() != sizeof(struct PNT::Position)) {
+			if (buf.size() != sizeof(struct PNT::Position_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for PNT::Position type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct PNT::Position));
+					std::to_string(sizeof(struct PNT::Position_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -145,10 +145,10 @@ namespace pirate {
 
 		static struct PNT::Distance fromBuffer(std::vector<char> const& buf) {
 			const struct PNT::Distance_wire* input = (const struct PNT::Distance_wire*) buf.data();
-			if (buf.size() != sizeof(struct PNT::Distance)) {
+			if (buf.size() != sizeof(struct PNT::Distance_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for PNT::Distance type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct PNT::Distance));
+					std::to_string(sizeof(struct PNT::Distance_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/pnt.cpp
+++ b/antlr/test/output/cpp/packed/pnt.cpp
@@ -83,7 +83,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct PNT::Position> {
 		static void toBuffer(struct PNT::Position const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct PNT::Position));
+			buf.resize(sizeof(struct PNT::Position_wire));
 			struct PNT::Position_wire* output = (struct PNT::Position_wire*) buf.data();
 			const struct PNT::Position* input = &val;
 			toWireType(input, output);
@@ -137,7 +137,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct PNT::Distance> {
 		static void toBuffer(struct PNT::Distance const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct PNT::Distance));
+			buf.resize(sizeof(struct PNT::Distance_wire));
 			struct PNT::Distance_wire* output = (struct PNT::Distance_wire*) buf.data();
 			const struct PNT::Distance* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/packed/primitives.cpp
+++ b/antlr/test/output/cpp/packed/primitives.cpp
@@ -229,10 +229,10 @@ namespace pirate {
 
 		static struct Primitives::Primitives fromBuffer(std::vector<char> const& buf) {
 			const struct Primitives::Primitives_wire* input = (const struct Primitives::Primitives_wire*) buf.data();
-			if (buf.size() != sizeof(struct Primitives::Primitives)) {
+			if (buf.size() != sizeof(struct Primitives::Primitives_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Primitives::Primitives type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Primitives::Primitives));
+					std::to_string(sizeof(struct Primitives::Primitives_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/primitives.cpp
+++ b/antlr/test/output/cpp/packed/primitives.cpp
@@ -221,7 +221,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Primitives::Primitives> {
 		static void toBuffer(struct Primitives::Primitives const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Primitives::Primitives));
+			buf.resize(sizeof(struct Primitives::Primitives_wire));
 			struct Primitives::Primitives_wire* output = (struct Primitives::Primitives_wire*) buf.data();
 			const struct Primitives::Primitives* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/packed/union.cpp
+++ b/antlr/test/output/cpp/packed/union.cpp
@@ -104,7 +104,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct UnionType::Union_Example> {
 		static void toBuffer(struct UnionType::Union_Example const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct UnionType::Union_Example));
+			buf.resize(sizeof(struct UnionType::Union_Example_wire));
 			struct UnionType::Union_Example_wire* output = (struct UnionType::Union_Example_wire*) buf.data();
 			const struct UnionType::Union_Example* input = &val;
 			toWireType(input, output);
@@ -112,10 +112,10 @@ namespace pirate {
 
 		static struct UnionType::Union_Example fromBuffer(std::vector<char> const& buf) {
 			const struct UnionType::Union_Example_wire* input = (const struct UnionType::Union_Example_wire*) buf.data();
-			if (buf.size() != sizeof(struct UnionType::Union_Example)) {
+			if (buf.size() != sizeof(struct UnionType::Union_Example_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for UnionType::Union_Example type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct UnionType::Union_Example));
+					std::to_string(sizeof(struct UnionType::Union_Example_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/packed/zero.cpp
+++ b/antlr/test/output/cpp/packed/zero.cpp
@@ -43,7 +43,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Zero::Zero> {
 		static void toBuffer(struct Zero::Zero const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Zero::Zero));
+			buf.resize(sizeof(struct Zero::Zero_wire));
 			struct Zero::Zero_wire* output = (struct Zero::Zero_wire*) buf.data();
 			const struct Zero::Zero* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/packed/zero.cpp
+++ b/antlr/test/output/cpp/packed/zero.cpp
@@ -51,10 +51,10 @@ namespace pirate {
 
 		static struct Zero::Zero fromBuffer(std::vector<char> const& buf) {
 			const struct Zero::Zero_wire* input = (const struct Zero::Zero_wire*) buf.data();
-			if (buf.size() != sizeof(struct Zero::Zero)) {
+			if (buf.size() != sizeof(struct Zero::Zero_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Zero::Zero type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Zero::Zero));
+					std::to_string(sizeof(struct Zero::Zero_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/pnt.cpp
+++ b/antlr/test/output/cpp/pnt.cpp
@@ -86,7 +86,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct PNT::Position> {
 		static void toBuffer(struct PNT::Position const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct PNT::Position));
+			buf.resize(sizeof(struct PNT::Position_wire));
 			struct PNT::Position_wire* output = (struct PNT::Position_wire*) buf.data();
 			const struct PNT::Position* input = &val;
 			toWireType(input, output);
@@ -141,7 +141,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct PNT::Distance> {
 		static void toBuffer(struct PNT::Distance const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct PNT::Distance));
+			buf.resize(sizeof(struct PNT::Distance_wire));
 			struct PNT::Distance_wire* output = (struct PNT::Distance_wire*) buf.data();
 			const struct PNT::Distance* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/pnt.cpp
+++ b/antlr/test/output/cpp/pnt.cpp
@@ -94,10 +94,10 @@ namespace pirate {
 
 		static struct PNT::Position fromBuffer(std::vector<char> const& buf) {
 			const struct PNT::Position_wire* input = (const struct PNT::Position_wire*) buf.data();
-			if (buf.size() != sizeof(struct PNT::Position)) {
+			if (buf.size() != sizeof(struct PNT::Position_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for PNT::Position type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct PNT::Position));
+					std::to_string(sizeof(struct PNT::Position_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);
@@ -149,10 +149,10 @@ namespace pirate {
 
 		static struct PNT::Distance fromBuffer(std::vector<char> const& buf) {
 			const struct PNT::Distance_wire* input = (const struct PNT::Distance_wire*) buf.data();
-			if (buf.size() != sizeof(struct PNT::Distance)) {
+			if (buf.size() != sizeof(struct PNT::Distance_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for PNT::Distance type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct PNT::Distance));
+					std::to_string(sizeof(struct PNT::Distance_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/primitives.cpp
+++ b/antlr/test/output/cpp/primitives.cpp
@@ -231,10 +231,10 @@ namespace pirate {
 
 		static struct Primitives::Primitives fromBuffer(std::vector<char> const& buf) {
 			const struct Primitives::Primitives_wire* input = (const struct Primitives::Primitives_wire*) buf.data();
-			if (buf.size() != sizeof(struct Primitives::Primitives)) {
+			if (buf.size() != sizeof(struct Primitives::Primitives_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Primitives::Primitives type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Primitives::Primitives));
+					std::to_string(sizeof(struct Primitives::Primitives_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/primitives.cpp
+++ b/antlr/test/output/cpp/primitives.cpp
@@ -223,7 +223,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Primitives::Primitives> {
 		static void toBuffer(struct Primitives::Primitives const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Primitives::Primitives));
+			buf.resize(sizeof(struct Primitives::Primitives_wire));
 			struct Primitives::Primitives_wire* output = (struct Primitives::Primitives_wire*) buf.data();
 			const struct Primitives::Primitives* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/union.cpp
+++ b/antlr/test/output/cpp/union.cpp
@@ -106,7 +106,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct UnionType::Union_Example> {
 		static void toBuffer(struct UnionType::Union_Example const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct UnionType::Union_Example));
+			buf.resize(sizeof(struct UnionType::Union_Example_wire));
 			struct UnionType::Union_Example_wire* output = (struct UnionType::Union_Example_wire*) buf.data();
 			const struct UnionType::Union_Example* input = &val;
 			toWireType(input, output);
@@ -114,10 +114,10 @@ namespace pirate {
 
 		static struct UnionType::Union_Example fromBuffer(std::vector<char> const& buf) {
 			const struct UnionType::Union_Example_wire* input = (const struct UnionType::Union_Example_wire*) buf.data();
-			if (buf.size() != sizeof(struct UnionType::Union_Example)) {
+			if (buf.size() != sizeof(struct UnionType::Union_Example_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for UnionType::Union_Example type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct UnionType::Union_Example));
+					std::to_string(sizeof(struct UnionType::Union_Example_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/cpp/zero.cpp
+++ b/antlr/test/output/cpp/zero.cpp
@@ -44,7 +44,7 @@ namespace pirate {
 	template<>
 	struct Serialization<struct Zero::Zero> {
 		static void toBuffer(struct Zero::Zero const& val, std::vector<char>& buf) {
-			buf.resize(sizeof(struct Zero::Zero));
+			buf.resize(sizeof(struct Zero::Zero_wire));
 			struct Zero::Zero_wire* output = (struct Zero::Zero_wire*) buf.data();
 			const struct Zero::Zero* input = &val;
 			toWireType(input, output);

--- a/antlr/test/output/cpp/zero.cpp
+++ b/antlr/test/output/cpp/zero.cpp
@@ -52,10 +52,10 @@ namespace pirate {
 
 		static struct Zero::Zero fromBuffer(std::vector<char> const& buf) {
 			const struct Zero::Zero_wire* input = (const struct Zero::Zero_wire*) buf.data();
-			if (buf.size() != sizeof(struct Zero::Zero)) {
+			if (buf.size() != sizeof(struct Zero::Zero_wire)) {
 				static const std::string error_msg =
 					std::string("pirate::Serialization::fromBuffer() for Zero::Zero type did not receive a buffer of size ") +
-					std::to_string(sizeof(struct Zero::Zero));
+					std::to_string(sizeof(struct Zero::Zero_wire));
 				throw std::length_error(error_msg);
 			}
 			return fromWireType(input);

--- a/antlr/test/output/dfdl/nested.dfdl.xsd
+++ b/antlr/test/output/dfdl/nested.dfdl.xsd
@@ -19,42 +19,42 @@
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
       <dfdl:defineFormat name="defaults">
-        <dfdl:format alignmentUnits="bits" binaryBooleanFalseRep="0" binaryBooleanTrueRep="1" binaryFloatRep="ieee" binaryNumberCheckPolicy="lax" binaryNumberRep="binary" bitOrder="mostSignificantBitFirst" byteOrder="bigEndian" choiceLengthKind="implicit" encoding="utf-8" encodingErrorPolicy="replace" escapeSchemeRef="" fillByte="%#r20;" floating="no" ignoreCase="no" initiatedContent="no" initiator="" leadingSkip="0" lengthKind="implicit" lengthUnits="bits" occursCountKind="implicit" prefixIncludesPrefixLength="no" representation="binary" separator="" separatorPosition="infix" sequenceKind="ordered" terminator="" textBidi="no" textPadKind="none" trailingSkip="0" truncateSpecifiedLengthString="no"/>
+        <dfdl:format alignmentUnits="bytes" binaryBooleanFalseRep="0" binaryBooleanTrueRep="1" binaryFloatRep="ieee" binaryNumberCheckPolicy="lax" binaryNumberRep="binary" bitOrder="mostSignificantBitFirst" byteOrder="bigEndian" choiceLengthKind="implicit" encoding="utf-8" encodingErrorPolicy="replace" escapeSchemeRef="" fillByte="%#r20;" floating="no" ignoreCase="no" initiatedContent="no" initiator="" leadingSkip="0" lengthKind="implicit" lengthUnits="bytes" occursCountKind="implicit" prefixIncludesPrefixLength="no" representation="binary" separator="" separatorPosition="infix" sequenceKind="ordered" terminator="" textBidi="no" textPadKind="none" trailingSkip="0" truncateSpecifiedLengthString="no"/>
       </dfdl:defineFormat>
       <dfdl:format ref="idl:defaults"/>
     </xs:appinfo>
   </xs:annotation>
-  <xs:simpleType name="float" dfdl:length="32" dfdl:lengthKind="explicit" dfdl:alignment="32">
+  <xs:simpleType name="float" dfdl:length="4" dfdl:lengthKind="explicit" dfdl:alignment="4">
     <xs:restriction base="xs:float"/>
   </xs:simpleType>
-  <xs:simpleType name="double" dfdl:length="64" dfdl:lengthKind="explicit" dfdl:alignment="64">
+  <xs:simpleType name="double" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
     <xs:restriction base="xs:double"/>
   </xs:simpleType>
-  <xs:simpleType name="int8" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
+  <xs:simpleType name="int8" dfdl:length="1" dfdl:lengthKind="explicit" dfdl:alignment="1">
     <xs:restriction base="xs:byte"/>
   </xs:simpleType>
-  <xs:simpleType name="int16" dfdl:length="16" dfdl:lengthKind="explicit" dfdl:alignment="16">
+  <xs:simpleType name="int16" dfdl:length="2" dfdl:lengthKind="explicit" dfdl:alignment="2">
     <xs:restriction base="xs:short"/>
   </xs:simpleType>
-  <xs:simpleType name="int32" dfdl:length="32" dfdl:lengthKind="explicit" dfdl:alignment="32">
+  <xs:simpleType name="int32" dfdl:length="4" dfdl:lengthKind="explicit" dfdl:alignment="4">
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
-  <xs:simpleType name="int64" dfdl:length="64" dfdl:lengthKind="explicit" dfdl:alignment="64">
+  <xs:simpleType name="int64" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
     <xs:restriction base="xs:long"/>
   </xs:simpleType>
-  <xs:simpleType name="uint8" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
+  <xs:simpleType name="uint8" dfdl:length="1" dfdl:lengthKind="explicit" dfdl:alignment="1">
     <xs:restriction base="xs:unsignedByte"/>
   </xs:simpleType>
-  <xs:simpleType name="uint16" dfdl:length="16" dfdl:lengthKind="explicit" dfdl:alignment="16">
+  <xs:simpleType name="uint16" dfdl:length="2" dfdl:lengthKind="explicit" dfdl:alignment="2">
     <xs:restriction base="xs:unsignedShort"/>
   </xs:simpleType>
-  <xs:simpleType name="uint32" dfdl:length="32" dfdl:lengthKind="explicit" dfdl:alignment="32">
+  <xs:simpleType name="uint32" dfdl:length="4" dfdl:lengthKind="explicit" dfdl:alignment="4">
     <xs:restriction base="xs:unsignedInt"/>
   </xs:simpleType>
-  <xs:simpleType name="uint64" dfdl:length="64" dfdl:lengthKind="explicit" dfdl:alignment="64">
+  <xs:simpleType name="uint64" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
     <xs:restriction base="xs:unsignedLong"/>
   </xs:simpleType>
-  <xs:simpleType name="boolean" dfdl:length="8" dfdl:lengthKind="explicit" dfdl:alignment="8">
+  <xs:simpleType name="boolean" dfdl:length="1" dfdl:lengthKind="explicit" dfdl:alignment="1">
     <xs:restriction base="xs:boolean"/>
   </xs:simpleType>
   <xs:complexType name="Foo">
@@ -73,28 +73,120 @@
     </xs:sequence>
   </xs:complexType>
   <xs:element name="BarDecl" type="idl:Bar"/>
-  <xs:complexType name="OuterStruct">
-    <xs:sequence>
-      <xs:element name="foo" type="idl:Foo"/>
-      <xs:element name="bar" type="idl:Bar"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="OuterStructDecl" type="idl:OuterStruct"/>
   <xs:simpleType name="DayOfWeek">
     <xs:restriction base="idl:uint32"/>
   </xs:simpleType>
+  <xs:complexType name="OuterStruct">
+    <xs:sequence>
+      <xs:element name="foo" type="idl:Foo"/>
+      <xs:element name="bar">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" minOccurs="2" maxOccurs="2" dfdl:occursCountKind="fixed">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="3" maxOccurs="3" dfdl:occursCountKind="fixed">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:Bar"/>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="day" type="idl:DayOfWeek"/>
+      <xs:element name="days">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" minOccurs="30" maxOccurs="30" dfdl:occursCountKind="fixed" type="idl:DayOfWeek"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="OuterStructDecl" type="idl:OuterStruct"/>
   <xs:complexType name="OuterUnion">
     <xs:sequence>
       <xs:element name="tag" type="idl:DayOfWeek"/>
-      <xs:element name="data" dfdl:length="192" dfdl:lengthKind="explicit" dfdl:alignment="64">
+      <xs:element name="data" dfdl:length="24" dfdl:lengthKind="explicit" dfdl:alignment="8">
         <xs:complexType>
           <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
-            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:Foo"/>
-            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:Bar"/>
+            <xs:element dfdl:choiceBranchKey="0" name="day" type="idl:DayOfWeek"/>
+            <xs:element dfdl:choiceBranchKey="1" name="days">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="30" maxOccurs="30" dfdl:occursCountKind="fixed" type="idl:DayOfWeek"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element dfdl:choiceBranchKey="2" name="foo" type="idl:Foo"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="2" maxOccurs="2" dfdl:occursCountKind="fixed">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="item" minOccurs="3" maxOccurs="3" dfdl:occursCountKind="fixed">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:Bar"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
           </xs:choice>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
   <xs:element name="OuterUnionDecl" type="idl:OuterUnion"/>
+  <xs:complexType name="ScopedOuterUnion">
+    <xs:sequence>
+      <xs:element name="tag" type="idl:DayOfWeek"/>
+      <xs:element name="data" dfdl:length="24" dfdl:lengthKind="explicit" dfdl:alignment="8">
+        <xs:complexType>
+          <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
+            <xs:element dfdl:choiceBranchKey="0" name="day" type="idl:DayOfWeek"/>
+            <xs:element dfdl:choiceBranchKey="1" name="days">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="30" maxOccurs="30" dfdl:occursCountKind="fixed" type="idl:DayOfWeek"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element dfdl:choiceBranchKey="2" name="foo" type="idl:Foo"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="2" maxOccurs="2" dfdl:occursCountKind="fixed">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="item" minOccurs="3" maxOccurs="3" dfdl:occursCountKind="fixed">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:Bar"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="ScopedOuterUnionDecl" type="idl:ScopedOuterUnion"/>
 </xs:schema>

--- a/antlr/test/output/dfdl/packed/nested.dfdl.xsd
+++ b/antlr/test/output/dfdl/packed/nested.dfdl.xsd
@@ -19,42 +19,42 @@
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
       <dfdl:defineFormat name="defaults">
-        <dfdl:format alignment="8" alignmentUnits="bits" binaryBooleanFalseRep="0" binaryBooleanTrueRep="1" binaryFloatRep="ieee" binaryNumberCheckPolicy="lax" binaryNumberRep="binary" bitOrder="mostSignificantBitFirst" byteOrder="bigEndian" choiceLengthKind="implicit" encoding="utf-8" encodingErrorPolicy="replace" escapeSchemeRef="" fillByte="%#r20;" floating="no" ignoreCase="no" initiatedContent="no" initiator="" leadingSkip="0" lengthKind="implicit" lengthUnits="bits" occursCountKind="implicit" prefixIncludesPrefixLength="no" representation="binary" separator="" separatorPosition="infix" sequenceKind="ordered" terminator="" textBidi="no" textPadKind="none" trailingSkip="0" truncateSpecifiedLengthString="no"/>
+        <dfdl:format alignment="1" alignmentUnits="bytes" binaryBooleanFalseRep="0" binaryBooleanTrueRep="1" binaryFloatRep="ieee" binaryNumberCheckPolicy="lax" binaryNumberRep="binary" bitOrder="mostSignificantBitFirst" byteOrder="bigEndian" choiceLengthKind="implicit" encoding="utf-8" encodingErrorPolicy="replace" escapeSchemeRef="" fillByte="%#r20;" floating="no" ignoreCase="no" initiatedContent="no" initiator="" leadingSkip="0" lengthKind="implicit" lengthUnits="bytes" occursCountKind="implicit" prefixIncludesPrefixLength="no" representation="binary" separator="" separatorPosition="infix" sequenceKind="ordered" terminator="" textBidi="no" textPadKind="none" trailingSkip="0" truncateSpecifiedLengthString="no"/>
       </dfdl:defineFormat>
       <dfdl:format ref="idl:defaults"/>
     </xs:appinfo>
   </xs:annotation>
-  <xs:simpleType name="float" dfdl:length="32" dfdl:lengthKind="explicit">
+  <xs:simpleType name="float" dfdl:length="4" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:float"/>
   </xs:simpleType>
-  <xs:simpleType name="double" dfdl:length="64" dfdl:lengthKind="explicit">
+  <xs:simpleType name="double" dfdl:length="8" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:double"/>
   </xs:simpleType>
-  <xs:simpleType name="int8" dfdl:length="8" dfdl:lengthKind="explicit">
+  <xs:simpleType name="int8" dfdl:length="1" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:byte"/>
   </xs:simpleType>
-  <xs:simpleType name="int16" dfdl:length="16" dfdl:lengthKind="explicit">
+  <xs:simpleType name="int16" dfdl:length="2" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:short"/>
   </xs:simpleType>
-  <xs:simpleType name="int32" dfdl:length="32" dfdl:lengthKind="explicit">
+  <xs:simpleType name="int32" dfdl:length="4" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:int"/>
   </xs:simpleType>
-  <xs:simpleType name="int64" dfdl:length="64" dfdl:lengthKind="explicit">
+  <xs:simpleType name="int64" dfdl:length="8" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:long"/>
   </xs:simpleType>
-  <xs:simpleType name="uint8" dfdl:length="8" dfdl:lengthKind="explicit">
+  <xs:simpleType name="uint8" dfdl:length="1" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:unsignedByte"/>
   </xs:simpleType>
-  <xs:simpleType name="uint16" dfdl:length="16" dfdl:lengthKind="explicit">
+  <xs:simpleType name="uint16" dfdl:length="2" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:unsignedShort"/>
   </xs:simpleType>
-  <xs:simpleType name="uint32" dfdl:length="32" dfdl:lengthKind="explicit">
+  <xs:simpleType name="uint32" dfdl:length="4" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:unsignedInt"/>
   </xs:simpleType>
-  <xs:simpleType name="uint64" dfdl:length="64" dfdl:lengthKind="explicit">
+  <xs:simpleType name="uint64" dfdl:length="8" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:unsignedLong"/>
   </xs:simpleType>
-  <xs:simpleType name="boolean" dfdl:length="8" dfdl:lengthKind="explicit">
+  <xs:simpleType name="boolean" dfdl:length="1" dfdl:lengthKind="explicit">
     <xs:restriction base="xs:boolean"/>
   </xs:simpleType>
   <xs:complexType name="Foo">
@@ -73,28 +73,120 @@
     </xs:sequence>
   </xs:complexType>
   <xs:element name="BarDecl" type="idl:Bar"/>
-  <xs:complexType name="OuterStruct">
-    <xs:sequence>
-      <xs:element name="foo" type="idl:Foo"/>
-      <xs:element name="bar" type="idl:Bar"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="OuterStructDecl" type="idl:OuterStruct"/>
   <xs:simpleType name="DayOfWeek">
     <xs:restriction base="idl:uint32"/>
   </xs:simpleType>
+  <xs:complexType name="OuterStruct">
+    <xs:sequence>
+      <xs:element name="foo" type="idl:Foo"/>
+      <xs:element name="bar">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" minOccurs="2" maxOccurs="2" dfdl:occursCountKind="fixed">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="3" maxOccurs="3" dfdl:occursCountKind="fixed">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:Bar"/>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="day" type="idl:DayOfWeek"/>
+      <xs:element name="days">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" minOccurs="30" maxOccurs="30" dfdl:occursCountKind="fixed" type="idl:DayOfWeek"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="OuterStructDecl" type="idl:OuterStruct"/>
   <xs:complexType name="OuterUnion">
     <xs:sequence>
       <xs:element name="tag" type="idl:DayOfWeek"/>
-      <xs:element name="data" dfdl:length="192" dfdl:lengthKind="explicit">
+      <xs:element name="data" dfdl:length="24" dfdl:lengthKind="explicit">
         <xs:complexType>
           <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
-            <xs:element dfdl:choiceBranchKey="0 1 2" name="foo" type="idl:Foo"/>
-            <xs:element dfdl:choiceBranchKey="3 4" name="bar" type="idl:Bar"/>
+            <xs:element dfdl:choiceBranchKey="0" name="day" type="idl:DayOfWeek"/>
+            <xs:element dfdl:choiceBranchKey="1" name="days">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="30" maxOccurs="30" dfdl:occursCountKind="fixed" type="idl:DayOfWeek"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element dfdl:choiceBranchKey="2" name="foo" type="idl:Foo"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="2" maxOccurs="2" dfdl:occursCountKind="fixed">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="item" minOccurs="3" maxOccurs="3" dfdl:occursCountKind="fixed">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:Bar"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
           </xs:choice>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
   <xs:element name="OuterUnionDecl" type="idl:OuterUnion"/>
+  <xs:complexType name="ScopedOuterUnion">
+    <xs:sequence>
+      <xs:element name="tag" type="idl:DayOfWeek"/>
+      <xs:element name="data" dfdl:length="24" dfdl:lengthKind="explicit">
+        <xs:complexType>
+          <xs:choice dfdl:choiceDispatchKey="{xs:string(../tag)}">
+            <xs:element dfdl:choiceBranchKey="0" name="day" type="idl:DayOfWeek"/>
+            <xs:element dfdl:choiceBranchKey="1" name="days">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="30" maxOccurs="30" dfdl:occursCountKind="fixed" type="idl:DayOfWeek"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element dfdl:choiceBranchKey="2" name="foo" type="idl:Foo"/>
+            <xs:element dfdl:choiceBranchKey="3 4" name="bar">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="item" minOccurs="2" maxOccurs="2" dfdl:occursCountKind="fixed">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="item" minOccurs="3" maxOccurs="3" dfdl:occursCountKind="fixed">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="item" minOccurs="4" maxOccurs="4" dfdl:occursCountKind="fixed" type="idl:Bar"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:choice>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="ScopedOuterUnionDecl" type="idl:ScopedOuterUnion"/>
 </xs:schema>


### PR DESCRIPTION
I think this code was only working when used with the unpacked generation where the struct sizes correspond.